### PR TITLE
chore(infra): migrate repo references to deelmarkt-org

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,8 +2,8 @@
 # CI workflow reads this file; no duplicate args in ci.yml.
 # Docs: https://docs.sonarsource.com/sonarcloud/
 
-sonar.projectKey=deelmarkt_app
-sonar.organization=deelmarkt
+sonar.projectKey=deelmarkt-org_app
+sonar.organization=deelmarkt-org
 sonar.projectName=DeelMarkt
 sonar.host.url=https://sonarcloud.io
 
@@ -14,7 +14,7 @@ sonar.sourceEncoding=UTF-8
 
 # PR decoration — post summary comments on GitHub PRs
 sonar.pullrequest.provider=GitHub
-sonar.pullrequest.github.repository=deelmarkt/app
+sonar.pullrequest.github.repository=deelmarkt-org/app
 
 # Coverage
 sonar.dart.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
## Summary

Updates all code references from the old org (`deelmarkt/app`) to the new org (`deelmarkt-org/app`).

## Code changes

| File | Change |
|------|--------|
| `sonar-project.properties` | `projectKey`, `organization`, `github.repository` → `deelmarkt-org` |
| `docs/MANUAL-TASKS-BELENGAZ.md` | 2 repo URL references |

## Manual tasks for repo owner

After merging, complete these on the new repo:

### 1. GitHub Secrets (CRITICAL — CI will fail without these)
At `https://github.com/deelmarkt-org/app/settings/secrets/actions`:

| Secret | Source |
|--------|--------|
| `SONAR_TOKEN` | SonarCloud → Security → Generate token |
| `SUPABASE_PROJECT_ID` | Supabase → Settings → API |
| `SUPABASE_ANON_PUBLIC` | Supabase → Settings → API |
| `ANTHROPIC_API_KEY` | Anthropic dashboard |

### 2. SonarCloud Re-binding
- Go to https://sonarcloud.io/projects
- Create new project: Org = `deelmarkt-org`, Key = `deelmarkt-org_app`
- Or update existing project key in Administration → General Settings

### 3. GitHub Apps
Install on `deelmarkt-org` org with access to this repo:
- [SonarCloud](https://github.com/apps/sonarcloud) — PR decoration
- [Gemini Code Assist](https://github.com/apps/gemini-code-assist-for-github) — AI review

### 4. Branch Protection
At `https://github.com/deelmarkt-org/app/settings/branches`:
- `main`: require PR, no direct push
- `dev`: require PR from feature branches

### 5. NOT affected (no changes needed)
- Supabase Edge Function URLs (use Supabase domain, not GitHub)
- Pre-commit hooks (no repo URL references)
- Deep link configs (use deelmarkt.com domain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)