### PR TITLE
fix: PR #9 review — DRY jsonResponse, debug-overrides, postcode normalize

### DIFF
--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -47,13 +47,6 @@
         </pin-set>
     </domain-config>
 
-    <!-- Debug builds only: allow user-installed CA certs for proxy tools (Charles, mitmproxy) -->
-    <debug-overrides>
-        <trust-anchors>
-            <certificates src="user" />
-        </trust-anchors>
-    </debug-overrides>
-
     <!-- Cloudinary CDN (res.cloudinary.com — user images) -->
     <domain-config cleartextTrafficPermitted="false">
         <domain includeSubdomains="true">cloudinary.com</domain>
@@ -64,4 +57,11 @@
             <pin digest="SHA-256">cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=</pin>
         </pin-set>
     </domain-config>
+
+    <!-- Debug builds only: allow user-installed CA certs for proxy tools (Charles, mitmproxy) -->
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
 </network-security-config>

--- a/supabase/functions/create-shipping-label/index.ts
+++ b/supabase/functions/create-shipping-label/index.ts
@@ -33,7 +33,7 @@ const AddressSchema = z.object({
   street: z.string().min(1),
   houseNumber: z.string().min(1),
   houseNumberAddition: z.string().optional(),
-  postcode: z.string().regex(/^\d{4}[A-Z]{2}$/),
+  postcode: z.string().transform((v) => v.toUpperCase()).pipe(z.string().regex(/^\d{4}[A-Z]{2}$/)),
   city: z.string().min(1),
   countryCode: z.string().length(2).default("NL"),
 });

--- a/supabase/functions/redis-health/index.ts
+++ b/supabase/functions/redis-health/index.ts
@@ -10,6 +10,7 @@
 
 import "@supabase/functions-js/edge-runtime.d.ts";
 import { verifyServiceRole } from "../_shared/auth.ts";
+import { jsonResponse } from "../_shared/response.ts";
 import {
   getRedisCredentials,
   redisSet,
@@ -70,10 +71,3 @@ Deno.serve(async (req: Request): Promise<Response> => {
     allOk ? 200 : 503,
   );
 });
-
-function jsonResponse(body: Record<string, unknown>, status: number): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
-}

--- a/supabase/functions/tracking-webhook/index.ts
+++ b/supabase/functions/tracking-webhook/index.ts
@@ -17,6 +17,7 @@ import "@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "jsr:@supabase/supabase-js@2";
 import { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
 import { getVaultSecret } from "../_shared/vault.ts";
+import { jsonResponse } from "../_shared/response.ts";
 import {
   getRedisCredentials,
   checkIdempotency,
@@ -196,10 +197,3 @@ Deno.serve(async (req: Request): Promise<Response> => {
     return jsonResponse({ error: "Internal error" }, 500);
   }
 });
-
-function jsonResponse(body: Record<string, unknown>, status: number): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
-}


### PR DESCRIPTION
Fixes 4 findings from the dev → main PR #9 review. Merge to dev, then PR #9 can proceed.

- **H1+H2**: `jsonResponse` in `redis-health` + `tracking-webhook` → shared `_shared/response.ts`
- **G1**: `<debug-overrides>` moved to last element per Android docs
- **M2**: Postcode normalized to uppercase via Zod `.transform().pipe()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)