### PR TITLE
fix: address PR #13 review findings (CRITICAL + HIGH + MEDIUM)

### DIFF
--- a/lib/core/router/auth_guard.dart
+++ b/lib/core/router/auth_guard.dart
@@ -5,6 +5,9 @@ import 'package:flutter/foundation.dart';
 import 'routes.dart';
 
 /// Routes that require authentication — redirect to onboarding if not logged in.
+///
+/// Note: `/listings/:id` is intentionally NOT protected — listing detail pages
+/// are public for SEO and sharing. Auth is required only for actions (buy, message).
 const _protectedRoutes = [
   AppRoutes.sell,
   AppRoutes.messages,

--- a/lib/features/home/data/mock/mock_listing_repository.dart
+++ b/lib/features/home/data/mock/mock_listing_repository.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import '../../domain/entities/listing_entity.dart';
 import '../../domain/repositories/listing_repository.dart';
 
@@ -6,7 +8,8 @@ import '../../domain/repositories/listing_repository.dart';
 /// Swapped for SupabaseListingRepository in Phase 4 via Riverpod override.
 /// Note: not thread-safe — single-isolate mock use only.
 class MockListingRepository implements ListingRepository {
-  Set<String> _favouriteIds = const <String>{};
+  @visibleForTesting
+  Set<String> favouriteIds = const <String>{};
 
   @override
   Future<List<ListingEntity>> getRecent({int limit = 20}) async {
@@ -79,19 +82,19 @@ class MockListingRepository implements ListingRepository {
   @override
   Future<ListingEntity> toggleFavourite(String listingId) async {
     await Future<void>.delayed(const Duration(milliseconds: 100));
-    if (_favouriteIds.contains(listingId)) {
-      _favouriteIds = {..._favouriteIds}..remove(listingId);
+    if (favouriteIds.contains(listingId)) {
+      favouriteIds = {...favouriteIds}..remove(listingId);
     } else {
-      _favouriteIds = {..._favouriteIds, listingId};
+      favouriteIds = {...favouriteIds, listingId};
     }
     final listing = _mockListings.firstWhere((l) => l.id == listingId);
-    return listing.copyWith(isFavourited: _favouriteIds.contains(listingId));
+    return listing.copyWith(isFavourited: favouriteIds.contains(listingId));
   }
 
   @override
   Future<List<ListingEntity>> getFavourites() async {
     await Future<void>.delayed(const Duration(milliseconds: 200));
-    return _mockListings.where((l) => _favouriteIds.contains(l.id)).toList();
+    return _mockListings.where((l) => favouriteIds.contains(l.id)).toList();
   }
 }
 

--- a/lib/features/messages/domain/entities/conversation_entity.dart
+++ b/lib/features/messages/domain/entities/conversation_entity.dart
@@ -1,7 +1,5 @@
 import 'package:equatable/equatable.dart';
 
-export 'message_entity.dart';
-
 /// Chat conversation between buyer and seller about a listing.
 ///
 /// Immutable value object — domain layer, no Flutter/Supabase imports.

--- a/lib/features/onboarding/presentation/onboarding_screen.dart
+++ b/lib/features/onboarding/presentation/onboarding_screen.dart
@@ -14,6 +14,8 @@ class OnboardingScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
     return Scaffold(
       body: SafeArea(
         child: Padding(
@@ -24,7 +26,9 @@ class OnboardingScreen extends StatelessWidget {
               Icon(
                 PhosphorIcons.shieldCheck(PhosphorIconsStyle.duotone),
                 size: 80,
-                color: DeelmarktColors.primary,
+                color: isDark
+                    ? DeelmarktColors.darkPrimary
+                    : DeelmarktColors.primary,
                 semanticLabel: 'onboarding.trust_icon_label'.tr(),
               ),
               const SizedBox(height: Spacing.s6),
@@ -32,14 +36,18 @@ class OnboardingScreen extends StatelessWidget {
                 'app.name'.tr(),
                 style: Theme.of(context).textTheme.displaySmall?.copyWith(
                   fontWeight: FontWeight.bold,
-                  color: DeelmarktColors.primary,
+                  color: isDark
+                      ? DeelmarktColors.darkPrimary
+                      : DeelmarktColors.primary,
                 ),
               ),
               const SizedBox(height: Spacing.s3),
               Text(
                 'app.tagline'.tr(),
                 style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  color: DeelmarktColors.neutral700,
+                  color: isDark
+                      ? DeelmarktColors.darkOnSurfaceSecondary
+                      : DeelmarktColors.neutral700,
                 ),
                 textAlign: TextAlign.center,
               ),
@@ -48,7 +56,9 @@ class OnboardingScreen extends StatelessWidget {
               Text(
                 'onboarding.placeholder'.tr(),
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: DeelmarktColors.neutral500,
+                  color: isDark
+                      ? DeelmarktColors.darkOnSurfaceSecondary
+                      : DeelmarktColors.neutral500,
                 ),
               ),
             ],

--- a/lib/features/profile/data/mock/mock_user_repository.dart
+++ b/lib/features/profile/data/mock/mock_user_repository.dart
@@ -26,7 +26,12 @@ class MockUserRepository implements UserRepository {
     String? location,
   }) async {
     await Future<void>.delayed(const Duration(milliseconds: 300));
-    return _mockUsers.first;
+    final user = _mockUsers.first;
+    return user.copyWith(
+      displayName: displayName ?? user.displayName,
+      avatarUrl: avatarUrl ?? user.avatarUrl,
+      location: location ?? user.location,
+    );
   }
 }
 

--- a/lib/features/profile/domain/entities/user_entity.dart
+++ b/lib/features/profile/domain/entities/user_entity.dart
@@ -47,6 +47,32 @@ class UserEntity extends Equatable {
     responseTimeMinutes,
     createdAt,
   ];
+
+  UserEntity copyWith({
+    String? id,
+    String? displayName,
+    String? avatarUrl,
+    String? location,
+    KycLevel? kycLevel,
+    List<BadgeType>? badges,
+    double? averageRating,
+    int? reviewCount,
+    int? responseTimeMinutes,
+    DateTime? createdAt,
+  }) {
+    return UserEntity(
+      id: id ?? this.id,
+      displayName: displayName ?? this.displayName,
+      avatarUrl: avatarUrl ?? this.avatarUrl,
+      location: location ?? this.location,
+      kycLevel: kycLevel ?? this.kycLevel,
+      badges: badges ?? this.badges,
+      averageRating: averageRating ?? this.averageRating,
+      reviewCount: reviewCount ?? this.reviewCount,
+      responseTimeMinutes: responseTimeMinutes ?? this.responseTimeMinutes,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
 }
 
 /// Progressive KYC levels — per E02 epic.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,12 @@ import 'core/services/firebase_service.dart';
 import 'core/services/supabase_service.dart';
 import 'core/services/unleash_service.dart';
 
+/// Fatal error message shown when app crashes before l10n is available.
+/// NL + EN fallback — extracted for testing and accessibility.
+const kFatalErrorMessage =
+    'Er ging iets mis. Start de app opnieuw.\n'
+    'Something went wrong. Please restart the app.';
+
 /// Riverpod provider for GoRouter — single instance, auth-aware.
 ///
 /// Passes `ref` to the router so the redirect function reads auth state
@@ -55,15 +61,17 @@ void main() async {
   // unavailable here. A minimal NL fallback is acceptable (§3.3 exception).
   if (!kDebugMode) {
     ErrorWidget.builder = (FlutterErrorDetails details) {
-      return const MaterialApp(
+      return MaterialApp(
         home: Scaffold(
           body: Center(
             child: Padding(
-              padding: EdgeInsets.all(Spacing.s6),
-              child: Text(
-                'Er ging iets mis. Start de app opnieuw.\n'
-                'Something went wrong. Please restart the app.',
-                textAlign: TextAlign.center,
+              padding: const EdgeInsets.all(Spacing.s6),
+              child: Semantics(
+                label: kFatalErrorMessage,
+                child: const Text(
+                  kFatalErrorMessage,
+                  textAlign: TextAlign.center,
+                ),
               ),
             ),
           ),

--- a/supabase/functions/create-shipping-label/index.ts
+++ b/supabase/functions/create-shipping-label/index.ts
@@ -130,7 +130,11 @@ async function createViaEctaro(
 
 /** PostNL base URL — sandbox or production based on POSTNL_ENV. */
 function getPostNLBaseUrl(): string {
-  const isSandbox = Deno.env.get("POSTNL_ENV") !== "production";
+  const postnlEnv = Deno.env.get("POSTNL_ENV");
+  if (!postnlEnv) {
+    console.warn("[create-shipping-label] POSTNL_ENV not set — defaulting to sandbox. Set POSTNL_ENV=production for live API.");
+  }
+  const isSandbox = postnlEnv !== "production";
   return isSandbox
     ? "https://api-sandbox.postnl.nl"
     : "https://api.postnl.nl";

--- a/supabase/functions/mollie-webhook/index.ts
+++ b/supabase/functions/mollie-webhook/index.ts
@@ -16,7 +16,7 @@ import { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
 import { getVaultSecret } from "../_shared/vault.ts";
 import { verifyServiceRole } from "../_shared/auth.ts";
 import { getRedisCredentials } from "../_shared/redis.ts";
-import { checkIdempotency } from "../_shared/idempotency.ts";
+import { checkIdempotency, rollbackIdempotency } from "../_shared/idempotency.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -277,6 +277,17 @@ Deno.serve(async (req: Request): Promise<Response> => {
     return new Response("OK", { status: 200 });
   } catch (error) {
     console.error(`[mollie-webhook] Error: ${(error as Error).message}`);
+
+    // Rollback idempotency key so Mollie can retry (CRITICAL: without this, retries are blocked for 24h)
+    try {
+      const bodyForRollback = await req.clone().text().catch(() => "");
+      const parsedForRollback = JSON.parse(bodyForRollback).id ?? "unknown";
+      const rollbackKey = `mollie:webhook:${parsedForRollback}`;
+      const redisCreds = getRedisCredentials();
+      await rollbackIdempotency(redisCreds, rollbackKey);
+    } catch {
+      // Best-effort rollback
+    }
 
     // Record failure for DLQ — preserve existing state
     try {

--- a/supabase/functions/postcode-lookup/index.ts
+++ b/supabase/functions/postcode-lookup/index.ts
@@ -46,6 +46,24 @@ class ProviderError extends Error {
   }
 }
 
+/** Request timeout for external provider calls (5 seconds). */
+const PROVIDER_TIMEOUT_MS = 5000;
+
+/** Fetch with timeout using AbortController. */
+async function fetchWithTimeout(
+  url: string,
+  options?: RequestInit,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), PROVIDER_TIMEOUT_MS);
+
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
 /**
  * Primary: postcode.tech — free tier 10,000 requests/month.
  * No API key required for basic usage.
@@ -58,10 +76,14 @@ async function lookupViaPostcodeTech(
 ): Promise<AddressResult | null> {
   const params = new URLSearchParams({ postcode, number: houseNumber });
   if (addition) params.set("addition", addition);
-  const resp = await fetch(
+  const resp = await fetchWithTimeout(
     `https://postcode.tech/api/v1/postcode/full?${params}`,
   );
 
+  if (resp.status === 429) {
+    console.warn("[postcode-lookup] postcode.tech rate limited (429) — free tier exhausted");
+    throw new ProviderError("postcode.tech", resp.status);
+  }
   if (resp.status >= 500) throw new ProviderError("postcode.tech", resp.status);
   if (!resp.ok) return null;
 
@@ -95,13 +117,17 @@ async function lookupViaApiPostcode(
 
   const params = new URLSearchParams({ postcode, number: houseNumber });
   if (addition) params.set("addition", addition);
-  const resp = await fetch(
+  const resp = await fetchWithTimeout(
     `https://json.api-postcode.nl?${params}`,
     {
       headers: { "X-Api-Key": apiKey },
     },
   );
 
+  if (resp.status === 429) {
+    console.warn("[postcode-lookup] api-postcode.nl rate limited (429) — daily quota exhausted");
+    throw new ProviderError("api-postcode.nl", resp.status);
+  }
   if (resp.status >= 500) throw new ProviderError("api-postcode.nl", resp.status);
   if (!resp.ok) return null;
 

--- a/test/core/router/auth_guard_test.dart
+++ b/test/core/router/auth_guard_test.dart
@@ -94,7 +94,7 @@ void main() {
   });
 
   group('GoRouterRefreshStream', () {
-    test('notifies on stream events', () {
+    test('notifies on stream events', () async {
       final controller = StreamController<int>();
       final stream = GoRouterRefreshStream(controller.stream);
 
@@ -102,7 +102,10 @@ void main() {
       stream.addListener(() => notifyCount++);
 
       controller.add(1);
+      // Pump event loop to allow stream event to be processed
+      await Future<void>.delayed(Duration.zero);
 
+      expect(notifyCount, equals(1));
       expect(controller.hasListener, isTrue);
 
       stream.dispose();

--- a/test/features/messages/domain/entities/conversation_entity_test.dart
+++ b/test/features/messages/domain/entities/conversation_entity_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:deelmarkt/features/messages/domain/entities/conversation_entity.dart';
+import 'package:deelmarkt/features/messages/domain/entities/message_entity.dart';
 
 void main() {
   group('ConversationEntity', () {
@@ -71,78 +72,6 @@ void main() {
     });
   });
 
-  group('MessageEntity', () {
-    test('equality when all fields match', () {
-      final a = MessageEntity(
-        id: 'm1',
-        conversationId: 'c1',
-        senderId: 'u1',
-        text: 'Hello',
-        createdAt: DateTime(2026, 1, 1),
-      );
-      final b = MessageEntity(
-        id: 'm1',
-        conversationId: 'c1',
-        senderId: 'u1',
-        text: 'Hello',
-        createdAt: DateTime(2026, 1, 1),
-      );
-
-      expect(a, equals(b));
-    });
-
-    test('inequality when fields differ', () {
-      final a = MessageEntity(
-        id: 'm1',
-        conversationId: 'c1',
-        senderId: 'u1',
-        text: 'Hello',
-        createdAt: DateTime(2026, 1, 1),
-      );
-      final b = MessageEntity(
-        id: 'm1',
-        conversationId: 'c1',
-        senderId: 'u1',
-        text: 'Hello',
-        createdAt: DateTime(2026, 1, 1),
-        isRead: true,
-      );
-
-      expect(a, isNot(equals(b)));
-    });
-
-    test('default type is text', () {
-      final msg = MessageEntity(
-        id: 'm1',
-        conversationId: 'c1',
-        senderId: 'u1',
-        text: 'Hi',
-        createdAt: DateTime(2026, 1, 1),
-      );
-
-      expect(msg.type, equals(MessageType.text));
-    });
-
-    test('default isRead is false', () {
-      final msg = MessageEntity(
-        id: 'm1',
-        conversationId: 'c1',
-        senderId: 'u1',
-        text: 'Hi',
-        createdAt: DateTime(2026, 1, 1),
-      );
-
-      expect(msg.isRead, isFalse);
-    });
-  });
-
-  group('MessageType', () {
-    test('has 4 types', () {
-      expect(MessageType.values.length, equals(4));
-    });
-
-    test('contains scamWarning', () {
-      expect(MessageType.values, contains(MessageType.scamWarning));
-    });
-  });
+  // MessageEntity tests moved to message_entity_test.dart — avoid duplication
+  // caused by conversation_entity.dart re-export (now removed).
 }


### PR DESCRIPTION
## Summary

Addresses all review findings from @emredursun's [PR #13 review](https://github.com/deelmarkt-org/app/pull/13#pullrequestreview-4025569673).

### CRITICAL (2)
- **mollie-webhook**: Add `rollbackIdempotency` call in catch block — prevents 24h retry lockout when processing fails after idempotency check
- **MockListingRepository**: Add `@visibleForTesting` annotation to `favouriteIds` field

### HIGH (6)
- **onboarding_screen**: Add dark mode support with `isDark` checks for all color references
- **conversation_entity**: Remove re-export of `message_entity.dart` (implicit coupling)
- **auth_guard**: Document that `/listings/:id` is intentionally public for SEO
- **create-shipping-label**: Log warning when `POSTNL_ENV` is unset (silent sandbox default)
- **main.dart**: Extract `kFatalErrorMessage` constant + add `Semantics` for accessibility

### MEDIUM (5)
- **MockUserRepository.updateProfile**: Apply `copyWith` with provided params instead of ignoring them
- **UserEntity**: Add `copyWith` method to support the above
- **conversation_entity_test**: Remove duplicate `MessageEntity` tests (caused by removed re-export)
- **postcode-lookup**: Add 5s timeout via `AbortController` for external HTTP calls
- **postcode-lookup**: Log 429 rate limit specifically per provider for ops visibility
- **auth_guard_test**: Fix async assertion with event loop pump

## Test plan
- [ ] `flutter analyze` passes
- [ ] `flutter test` passes
- [ ] Verify mollie-webhook rollback logic in integration test
- [ ] Verify onboarding screen renders correctly in dark mode

Slack thread: https://deelmarkt.slack.com/archives/D0APVCZ5L6M/p1774709439687999?thread_ts=1774709207.686569&cid=D0APVCZ5L6M

https://claude.ai/code/session_01QxNaEfKRRuJzB9iFHSNokb