### PR TITLE
ci: add CodeQL workflow for code scanning baseline

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+  schedule:
+    - cron: '0 5 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['javascript-typescript']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Adds GitHub CodeQL analysis workflow for JavaScript/TypeScript
- Runs on push to main/dev, on PRs targeting main/dev, and weekly (Monday 05:00 UTC)
- Creates the code scanning baseline required for PR merge protection

## Context
This unblocks PR #13 which requires code scanning results on the target branch (main).

## Test plan
- [x] Verify CodeQL workflow runs successfully on this PR
- [x] After merge, verify code scanning baseline is established on main
- [x] Verify PR #13 no longer blocked by missing code scanning results