### PR TITLE
fix(og-worker,db): address PR #29 review comments

### DIFF
--- a/cloudflare/og-worker/README.md
+++ b/cloudflare/og-worker/README.md
@@ -37,10 +37,10 @@ cd cloudflare/og-worker
 
 # Set secrets (one-time)
 wrangler secret put SUPABASE_URL
-# Enter: your Supabase project URL (from .env SUPABASE_PROJECT_ID → https://{id}.supabase.co)
+# Enter: your Supabase project URL (found in root .env as SUPABASE_PROJECT_ID → https://<project-id>.supabase.co)
 
 wrangler secret put SUPABASE_ANON_KEY
-# Enter: your Supabase anon key (from .env SUPABASE_ANON_PUBLIC)
+# Enter: your Supabase anon key (found in root .env as SUPABASE_ANON_PUBLIC)
 
 # Deploy
 wrangler deploy

--- a/cloudflare/og-worker/worker.js
+++ b/cloudflare/og-worker/worker.js
@@ -154,7 +154,7 @@ async function handleListing(id, url, env) {
   try {
     const resp = await supabaseFetch(
       env,
-      `listings?id=eq.${encodeURIComponent(id)}&select=id,title,description,price_cents,category,condition,images,is_sold,seller:users!seller_id(display_name,avatar_url)`
+      `listings?id=eq.${encodeURIComponent(id)}&select=id,title,description,price_cents,category,condition,images,is_sold,seller:user_profiles!seller_id(display_name,avatar_url)`
     );
 
     if (!resp.ok) {
@@ -206,7 +206,7 @@ async function handleUser(id, url, env) {
   try {
     const resp = await supabaseFetch(
       env,
-      `users?id=eq.${encodeURIComponent(id)}&select=id,display_name,avatar_url,location,average_rating,review_count`
+      `user_profiles?id=eq.${encodeURIComponent(id)}&select=id,display_name,avatar_url,location,average_rating,review_count`
     );
 
     if (!resp.ok) {
@@ -354,51 +354,20 @@ async function handleShipping(id, subpath, url, env) {
 }
 
 /**
- * Fetch conversation context from Supabase and return OG tags.
+ * Return default OG tags for messages routes.
+ * The conversations table does not exist yet (planned for a future sprint).
+ * Once messaging is implemented, this can be updated to fetch conversation context.
  */
 async function handleMessages(id, url, env) {
-  if (!isValidId(id)) {
-    return renderOgHtml({ ...DEFAULT_OG, url: url.toString(), siteName: 'DeelMarkt' }, env);
-  }
-
-  try {
-    const resp = await supabaseFetch(
-      env,
-      `conversations?id=eq.${encodeURIComponent(id)}&select=id,listing_title,listing_image_url`
-    );
-
-    if (!resp.ok) {
-      return renderOgHtml({ ...DEFAULT_OG, url: url.toString(), siteName: 'DeelMarkt' }, env);
-    }
-
-    const conversations = await resp.json();
-    if (!conversations || conversations.length === 0) {
-      return renderOgHtml({
-        title: 'Berichten — DeelMarkt',
-        description: 'Stuur berichten op DeelMarkt. Veilig chatten met ingebouwde oplichtersbescherming.',
-        image: DEFAULT_OG.image,
-        type: 'website',
-        url: url.toString(),
-        siteName: 'DeelMarkt',
-        locale: 'nl_NL',
-      }, env);
-    }
-
-    const conv = conversations[0];
-
-    return renderOgHtml({
-      title: `Chat over "${conv.listing_title || 'artikel'}" — DeelMarkt`,
-      description: 'Veilig chatten op DeelMarkt met ingebouwde oplichtersbescherming.',
-      image: conv.listing_image_url || DEFAULT_OG.image,
-      type: 'website',
-      url: url.toString(),
-      siteName: 'DeelMarkt',
-      locale: 'nl_NL',
-    }, env);
-  } catch (err) {
-    console.error(`[og-worker] Messages fetch failed: ${err.message}`);
-    return renderOgHtml({ ...DEFAULT_OG, url: url.toString(), siteName: 'DeelMarkt' }, env);
-  }
+  return renderOgHtml({
+    title: 'Berichten — DeelMarkt',
+    description: 'Stuur berichten op DeelMarkt. Veilig chatten met ingebouwde oplichtersbescherming.',
+    image: DEFAULT_OG.image,
+    type: 'website',
+    url: url.toString(),
+    siteName: 'DeelMarkt',
+    locale: 'nl_NL',
+  }, env);
 }
 
 /**

--- a/supabase/migrations/20260329200137_phase_a_review_fixes.sql
+++ b/supabase/migrations/20260329200137_phase_a_review_fixes.sql
@@ -1,59 +1,8 @@
--- Phase A PR #27 review fixes — bounding box optimization + RLS sold filter
--- Addresses: Gemini HIGH (sold items visible, full scan), emredursun M3 (count comment)
+-- Phase A PR #27 review fixes — consolidated into audit_fixes migration
+-- The RLS policy fix and nearby_listings optimization are already applied
+-- in 20260329192715_phase_a_audit_fixes.sql. This migration is kept as a
+-- no-op to preserve migration history ordering.
 
--- =============================================================================
--- 1. RLS: Sold items should not be publicly visible
--- =============================================================================
-
-DROP POLICY IF EXISTS listings_select ON listings;
-CREATE POLICY listings_select ON listings
-  FOR SELECT USING ((is_active = true AND is_sold = false) OR auth.uid() = seller_id);
-
--- =============================================================================
--- 2. Bounding box optimization for nearby_listings
--- =============================================================================
--- Pre-filters using B-tree index on (latitude, longitude) before computing
--- expensive haversine. ~100x faster than full table scan at scale.
-
-CREATE OR REPLACE FUNCTION nearby_listings(
-  user_lat DOUBLE PRECISION,
-  user_lon DOUBLE PRECISION,
-  radius_km DOUBLE PRECISION DEFAULT 25.0,
-  max_results INTEGER DEFAULT 50
-)
-RETURNS TABLE (
-  listing_id UUID,
-  distance_km DOUBLE PRECISION
-) AS $$
-DECLARE
-  -- 1 degree latitude ≈ 111km. Longitude varies by cos(lat).
-  lat_delta DOUBLE PRECISION := radius_km / 111.0;
-  lon_delta DOUBLE PRECISION := radius_km / (111.0 * cos(radians(user_lat)));
-BEGIN
-  RETURN QUERY
-  SELECT sub.listing_id, sub.distance_km
-  FROM (
-    SELECT
-      l.id AS listing_id,
-      haversine_km(user_lat, user_lon, l.latitude, l.longitude) AS distance_km
-    FROM listings l
-    WHERE l.is_active = true
-      AND l.is_sold = false
-      AND l.latitude IS NOT NULL
-      AND l.longitude IS NOT NULL
-      -- Bounding box pre-filter (uses B-tree index on latitude, longitude)
-      AND l.latitude BETWEEN (user_lat - lat_delta) AND (user_lat + lat_delta)
-      AND l.longitude BETWEEN (user_lon - lon_delta) AND (user_lon + lon_delta)
-  ) sub
-  WHERE sub.distance_km <= radius_km
-  ORDER BY sub.distance_km ASC
-  LIMIT max_results;
-END;
-$$ LANGUAGE plpgsql STABLE;
-
--- =============================================================================
--- 3. Add scale comment to favourite_count trigger (emredursun M3)
--- =============================================================================
--- Note: count(*) is accurate but slow at scale (>100K rows).
+-- Note: count(*) in favourite_count trigger is accurate but slow at scale (>100K rows).
 -- Revisit with pg_advisory_lock or deferred batch updates when needed.
 -- For MVP volume (<10K favourites) this is fine.

--- a/supabase/migrations/20260330003331_phase_a_round3_fixes.sql
+++ b/supabase/migrations/20260330003331_phase_a_round3_fixes.sql
@@ -42,36 +42,35 @@ LEFT JOIN user_profiles up ON up.id = l.seller_id;
 
 ALTER TABLE categories ADD COLUMN listing_count INTEGER NOT NULL DEFAULT 0;
 
--- Function to update category listing count
+-- Function to update category listing count (incremental +1/-1 for performance)
 CREATE OR REPLACE FUNCTION update_category_listing_count()
 RETURNS TRIGGER AS $$
 BEGIN
   IF TG_OP = 'INSERT' THEN
-    UPDATE categories SET listing_count = (
-      SELECT count(*) FROM listings WHERE category_id = NEW.category_id AND is_active = true AND is_sold = false
-    ) WHERE id = NEW.category_id;
+    IF NEW.is_active = true AND NEW.is_sold = false AND NEW.category_id IS NOT NULL THEN
+      UPDATE categories SET listing_count = listing_count + 1 WHERE id = NEW.category_id;
+    END IF;
     RETURN NEW;
   ELSIF TG_OP = 'DELETE' THEN
-    UPDATE categories SET listing_count = (
-      SELECT count(*) FROM listings WHERE category_id = OLD.category_id AND is_active = true AND is_sold = false
-    ) WHERE id = OLD.category_id;
+    IF OLD.is_active = true AND OLD.is_sold = false AND OLD.category_id IS NOT NULL THEN
+      UPDATE categories SET listing_count = GREATEST(listing_count - 1, 0) WHERE id = OLD.category_id;
+    END IF;
     RETURN OLD;
   ELSIF TG_OP = 'UPDATE' THEN
-    -- Category changed, or listing sold/deactivated
-    IF OLD.category_id IS DISTINCT FROM NEW.category_id
-       OR OLD.is_active IS DISTINCT FROM NEW.is_active
-       OR OLD.is_sold IS DISTINCT FROM NEW.is_sold THEN
-      -- Update old category count
-      IF OLD.category_id IS NOT NULL THEN
-        UPDATE categories SET listing_count = (
-          SELECT count(*) FROM listings WHERE category_id = OLD.category_id AND is_active = true AND is_sold = false
-        ) WHERE id = OLD.category_id;
+    -- Determine if old row was counted
+    IF OLD.is_active = true AND OLD.is_sold = false AND OLD.category_id IS NOT NULL THEN
+      -- Old row was active — decrement old category
+      IF OLD.category_id IS DISTINCT FROM NEW.category_id
+         OR NEW.is_active = false OR NEW.is_sold = true THEN
+        UPDATE categories SET listing_count = GREATEST(listing_count - 1, 0) WHERE id = OLD.category_id;
       END IF;
-      -- Update new category count (if category changed)
-      IF NEW.category_id IS DISTINCT FROM OLD.category_id AND NEW.category_id IS NOT NULL THEN
-        UPDATE categories SET listing_count = (
-          SELECT count(*) FROM listings WHERE category_id = NEW.category_id AND is_active = true AND is_sold = false
-        ) WHERE id = NEW.category_id;
+    END IF;
+    -- Determine if new row should be counted
+    IF NEW.is_active = true AND NEW.is_sold = false AND NEW.category_id IS NOT NULL THEN
+      -- New row is active — increment new category
+      IF NEW.category_id IS DISTINCT FROM OLD.category_id
+         OR OLD.is_active = false OR OLD.is_sold = true THEN
+        UPDATE categories SET listing_count = listing_count + 1 WHERE id = NEW.category_id;
       END IF;
     END IF;
     RETURN NEW;


### PR DESCRIPTION
## Summary
- Fix OG worker queries to use `user_profiles` instead of `users` table (critical bugs)
- Replace `handleMessages` DB call with static OG tags (conversations table not yet created)
- Use incremental `+1/-1` in category `listing_count` trigger instead of `count(*)`
- Clarify `.env` variable references in OG worker README
- Remove duplicate migration content from `review_fixes` (already in `audit_fixes`)

Addresses all 6 Gemini Code Assist comments on PR #29.

## Test plan
- [ ] Verify OG worker `/listings/:id` returns seller name (join on `user_profiles`)
- [ ] Verify OG worker `/users/:id` returns profile data
- [ ] Verify `/messages/:id` returns default OG tags without DB error
- [ ] Verify category `listing_count` stays accurate after insert/update/delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)