### PR TITLE
test(coverage): boost new code coverage for PR #29 quality gate

### DIFF
--- a/test/core/design_system/breakpoints_test.dart
+++ b/test/core/design_system/breakpoints_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:deelmarkt/core/design_system/breakpoints.dart';
+
+void main() {
+  group('Breakpoints constants', () {
+    test('compact is 600', () {
+      expect(Breakpoints.compact, 600);
+    });
+
+    test('medium is 840', () {
+      expect(Breakpoints.medium, 840);
+    });
+
+    test('expanded is 1200', () {
+      expect(Breakpoints.expanded, 1200);
+    });
+
+    test('contentMaxWidth is 500', () {
+      expect(Breakpoints.contentMaxWidth, 500);
+    });
+  });
+
+  group('Breakpoints helpers', () {
+    testWidgets('isCompact returns true for narrow screens', (tester) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      late bool result;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              result = Breakpoints.isCompact(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(result, isTrue);
+    });
+
+    testWidgets('isCompact returns false for wide screens', (tester) async {
+      tester.view.physicalSize = const Size(700, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      late bool result;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              result = Breakpoints.isCompact(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(result, isFalse);
+    });
+
+    testWidgets('isMedium returns true between compact and medium', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(700, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      late bool result;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              result = Breakpoints.isMedium(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(result, isTrue);
+    });
+
+    testWidgets('isMedium returns false for expanded screens', (tester) async {
+      tester.view.physicalSize = const Size(900, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      late bool result;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              result = Breakpoints.isMedium(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(result, isFalse);
+    });
+
+    testWidgets('isExpanded returns true for wide screens', (tester) async {
+      tester.view.physicalSize = const Size(900, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      late bool result;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              result = Breakpoints.isExpanded(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(result, isTrue);
+    });
+
+    testWidgets('isExpanded returns false for compact screens', (tester) async {
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      late bool result;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              result = Breakpoints.isExpanded(context);
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(result, isFalse);
+    });
+  });
+}

--- a/test/core/design_system_test.dart
+++ b/test/core/design_system_test.dart
@@ -175,6 +175,164 @@ void main() {
     });
   });
 
+  group('DeelmarktTheme light — component themes', () {
+    test('elevatedButton has primary background', () {
+      final style = DeelmarktTheme.light.elevatedButtonTheme.style!;
+      final bg = style.backgroundColor?.resolve({});
+      expect(bg, DeelmarktColors.primary);
+    });
+
+    test('elevatedButton has 52px min height', () {
+      final style = DeelmarktTheme.light.elevatedButtonTheme.style!;
+      final size = style.minimumSize?.resolve({});
+      expect(size?.height, 52);
+    });
+
+    test('card has neutral200 border', () {
+      final shape =
+          DeelmarktTheme.light.cardTheme.shape as RoundedRectangleBorder;
+      expect(shape.side.color, DeelmarktColors.neutral200);
+    });
+
+    test('card has zero elevation', () {
+      expect(DeelmarktTheme.light.cardTheme.elevation, 0);
+    });
+
+    test('navigationBar background is white', () {
+      expect(
+        DeelmarktTheme.light.navigationBarTheme.backgroundColor,
+        DeelmarktColors.white,
+      );
+    });
+
+    test('navigationBar indicator uses primarySurface', () {
+      expect(
+        DeelmarktTheme.light.navigationBarTheme.indicatorColor,
+        DeelmarktColors.primarySurface,
+      );
+    });
+
+    test('inputDecoration error border uses error color', () {
+      final errorBorder =
+          DeelmarktTheme.light.inputDecorationTheme.errorBorder
+              as OutlineInputBorder;
+      expect(errorBorder.borderSide.color, DeelmarktColors.error);
+    });
+
+    test('inputDecoration focused border uses primary with width 2', () {
+      final focusedBorder =
+          DeelmarktTheme.light.inputDecorationTheme.focusedBorder
+              as OutlineInputBorder;
+      expect(focusedBorder.borderSide.color, DeelmarktColors.primary);
+      expect(focusedBorder.borderSide.width, 2);
+    });
+
+    test('segmentedButton selected state uses primary', () {
+      final style = DeelmarktTheme.light.segmentedButtonTheme.style!;
+      final bg = style.backgroundColor!.resolve({WidgetState.selected});
+      expect(bg, DeelmarktColors.primary);
+    });
+
+    test('segmentedButton unselected state is transparent', () {
+      final style = DeelmarktTheme.light.segmentedButtonTheme.style!;
+      final bg = style.backgroundColor!.resolve({});
+      expect(bg, Colors.transparent);
+    });
+
+    test('segmentedButton min height is 44 (WCAG)', () {
+      final style = DeelmarktTheme.light.segmentedButtonTheme.style!;
+      final size = style.minimumSize!.resolve({});
+      expect(size?.height, 44);
+    });
+
+    test('colorScheme secondary is DeelMarkt blue', () {
+      expect(
+        DeelmarktTheme.light.colorScheme.secondary,
+        DeelmarktColors.secondary,
+      );
+    });
+
+    test('colorScheme error is DeelMarkt error', () {
+      expect(DeelmarktTheme.light.colorScheme.error, DeelmarktColors.error);
+    });
+
+    test('divider uses neutral200', () {
+      expect(
+        DeelmarktTheme.light.dividerTheme.color,
+        DeelmarktColors.neutral200,
+      );
+    });
+
+    test('appBar elevation is 0', () {
+      expect(DeelmarktTheme.light.appBarTheme.elevation, 0);
+    });
+
+    test('appBar scrolledUnderElevation is 1', () {
+      expect(DeelmarktTheme.light.appBarTheme.scrolledUnderElevation, 1);
+    });
+
+    test('has DeelButtonThemeData extension', () {
+      expect(DeelmarktTheme.light.extensions.isNotEmpty, true);
+    });
+  });
+
+  group('DeelmarktTheme dark — component themes', () {
+    test('navigationBar background is darkSurface', () {
+      expect(
+        DeelmarktTheme.dark.navigationBarTheme.backgroundColor,
+        DeelmarktColors.darkSurface,
+      );
+    });
+
+    test('divider uses darkDivider', () {
+      expect(
+        DeelmarktTheme.dark.dividerTheme.color,
+        DeelmarktColors.darkDivider,
+      );
+    });
+
+    test('segmentedButton selected state uses darkPrimary', () {
+      final style = DeelmarktTheme.dark.segmentedButtonTheme.style!;
+      final bg = style.backgroundColor!.resolve({WidgetState.selected});
+      expect(bg, DeelmarktColors.darkPrimary);
+    });
+
+    test('segmentedButton foreground selected uses darkOnPrimary', () {
+      final style = DeelmarktTheme.dark.segmentedButtonTheme.style!;
+      final fg = style.foregroundColor!.resolve({WidgetState.selected});
+      expect(fg, DeelmarktColors.darkOnPrimary);
+    });
+
+    test(
+      'segmentedButton foreground unselected uses darkOnSurfaceSecondary',
+      () {
+        final style = DeelmarktTheme.dark.segmentedButtonTheme.style!;
+        final fg = style.foregroundColor!.resolve({});
+        expect(fg, DeelmarktColors.darkOnSurfaceSecondary);
+      },
+    );
+
+    test('elevatedButton uses darkPrimary', () {
+      final style = DeelmarktTheme.dark.elevatedButtonTheme.style!;
+      final bg = style.backgroundColor?.resolve({});
+      expect(bg, DeelmarktColors.darkPrimary);
+    });
+
+    test('inputDecoration focused border uses darkPrimary', () {
+      final focusedBorder =
+          DeelmarktTheme.dark.inputDecorationTheme.focusedBorder
+              as OutlineInputBorder;
+      expect(focusedBorder.borderSide.color, DeelmarktColors.darkPrimary);
+    });
+
+    test('inputDecoration error border uses darkError', () {
+      final errorBorder =
+          DeelmarktTheme.dark.inputDecorationTheme.errorBorder
+              as OutlineInputBorder;
+      expect(errorBorder.borderSide.color, DeelmarktColors.darkError);
+    });
+  });
+
   group('Theme renders', () {
     testWidgets('light theme applies to MaterialApp', (tester) async {
       await tester.pumpWidget(

--- a/test/core/router_test.dart
+++ b/test/core/router_test.dart
@@ -121,6 +121,64 @@ void main() {
     });
   });
 
+  group('GoRouter shipping sub-routes', () {
+    testWidgets('navigates to shipping QR sub-route', (tester) async {
+      final authedRouter = _createTestRouter(isLoggedIn: true);
+      authedRouter.go('/shipping/ship-1/qr');
+      await tester.pumpWidget(MaterialApp.router(routerConfig: authedRouter));
+      await tester.pumpAndSettle();
+      expect(find.text('Shipping QR ship-1'), findsWidgets);
+      authedRouter.dispose();
+    });
+
+    testWidgets('navigates to shipping tracking sub-route', (tester) async {
+      final authedRouter = _createTestRouter(isLoggedIn: true);
+      authedRouter.go('/shipping/ship-1/tracking');
+      await tester.pumpWidget(MaterialApp.router(routerConfig: authedRouter));
+      await tester.pumpAndSettle();
+      expect(find.text('Tracking ship-1'), findsWidgets);
+      authedRouter.dispose();
+    });
+
+    testWidgets('navigates to parcel shops sub-route', (tester) async {
+      final authedRouter = _createTestRouter(isLoggedIn: true);
+      authedRouter.go('/shipping/ship-1/parcel-shops');
+      await tester.pumpWidget(MaterialApp.router(routerConfig: authedRouter));
+      await tester.pumpAndSettle();
+      expect(find.text('Parcel Shops ship-1'), findsWidgets);
+      authedRouter.dispose();
+    });
+  });
+
+  group('GoRouter tab routes', () {
+    testWidgets('sell tab shows placeholder', (tester) async {
+      final authedRouter = _createTestRouter(isLoggedIn: true);
+      authedRouter.go('/sell');
+      await tester.pumpWidget(MaterialApp.router(routerConfig: authedRouter));
+      await tester.pumpAndSettle();
+      expect(find.text('Sell'), findsWidgets);
+      authedRouter.dispose();
+    });
+
+    testWidgets('messages tab shows placeholder', (tester) async {
+      final authedRouter = _createTestRouter(isLoggedIn: true);
+      authedRouter.go('/messages');
+      await tester.pumpWidget(MaterialApp.router(routerConfig: authedRouter));
+      await tester.pumpAndSettle();
+      expect(find.text('Messages'), findsWidgets);
+      authedRouter.dispose();
+    });
+
+    testWidgets('profile tab shows placeholder', (tester) async {
+      final authedRouter = _createTestRouter(isLoggedIn: true);
+      authedRouter.go('/profile');
+      await tester.pumpWidget(MaterialApp.router(routerConfig: authedRouter));
+      await tester.pumpAndSettle();
+      expect(find.text('Profile'), findsWidgets);
+      authedRouter.dispose();
+    });
+  });
+
   group('GoRouter auth guard integration', () {
     testWidgets('redirects /sell to /onboarding when not logged in', (
       tester,

--- a/test/features/home/domain/entities/listing_entity_test.dart
+++ b/test/features/home/domain/entities/listing_entity_test.dart
@@ -100,6 +100,61 @@ void main() {
     });
   });
 
+  group('ListingEntity copyWith — all fields', () {
+    test('returns identical entity when no fields overridden', () {
+      expect(listing.copyWith(), equals(listing));
+    });
+
+    test('overrides title', () {
+      final updated = listing.copyWith(title: 'New Title');
+      expect(updated.title, 'New Title');
+      expect(updated.id, listing.id);
+    });
+
+    test('overrides priceInCents', () {
+      final updated = listing.copyWith(priceInCents: 9999);
+      expect(updated.priceInCents, 9999);
+    });
+
+    test('overrides condition', () {
+      final updated = listing.copyWith(condition: ListingCondition.poor);
+      expect(updated.condition, ListingCondition.poor);
+    });
+
+    test('overrides imageUrls', () {
+      final updated = listing.copyWith(imageUrls: ['a.jpg', 'b.jpg']);
+      expect(updated.imageUrls, ['a.jpg', 'b.jpg']);
+    });
+
+    test('overrides location and distanceKm', () {
+      final updated = listing.copyWith(location: 'Rotterdam', distanceKm: 12.5);
+      expect(updated.location, 'Rotterdam');
+      expect(updated.distanceKm, 12.5);
+    });
+
+    test('overrides multiple fields at once', () {
+      final updated = listing.copyWith(
+        title: 'Updated',
+        priceInCents: 100,
+        sellerId: 'user-2',
+        sellerName: 'Other User',
+        categoryId: 'cat-2',
+        createdAt: DateTime(2026, 6, 1),
+      );
+      expect(updated.title, 'Updated');
+      expect(updated.priceInCents, 100);
+      expect(updated.sellerId, 'user-2');
+      expect(updated.sellerName, 'Other User');
+      expect(updated.categoryId, 'cat-2');
+      expect(updated.createdAt, DateTime(2026, 6, 1));
+    });
+
+    test('overrides description', () {
+      final updated = listing.copyWith(description: 'New description');
+      expect(updated.description, 'New description');
+    });
+  });
+
   group('ListingCondition', () {
     test('has 6 values', () {
       expect(ListingCondition.values.length, equals(6));

--- a/test/features/onboarding/presentation/widgets/trust_feature_card_test.dart
+++ b/test/features/onboarding/presentation/widgets/trust_feature_card_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:deelmarkt/core/design_system/colors.dart';
+import 'package:deelmarkt/core/design_system/theme.dart';
+import 'package:deelmarkt/features/onboarding/presentation/widgets/trust_feature_card.dart';
+
+void main() {
+  Widget buildCard({
+    IconData icon = Icons.verified_user,
+    String title = 'Test Title',
+    String subtitle = 'Test Subtitle',
+    Color iconColor = DeelmarktColors.primary,
+  }) {
+    return MaterialApp(
+      theme: DeelmarktTheme.light,
+      home: Scaffold(
+        body: TrustFeatureCard(
+          icon: icon,
+          title: title,
+          subtitle: subtitle,
+          iconColor: iconColor,
+        ),
+      ),
+    );
+  }
+
+  group('TrustFeatureCard', () {
+    testWidgets('renders title and subtitle', (tester) async {
+      await tester.pumpWidget(buildCard());
+
+      expect(find.text('Test Title'), findsOneWidget);
+      expect(find.text('Test Subtitle'), findsOneWidget);
+    });
+
+    testWidgets('renders icon', (tester) async {
+      await tester.pumpWidget(buildCard(icon: Icons.shield));
+
+      expect(find.byIcon(Icons.shield), findsOneWidget);
+    });
+
+    testWidgets('applies icon color', (tester) async {
+      await tester.pumpWidget(buildCard(iconColor: DeelmarktColors.success));
+
+      final icon = tester.widget<Icon>(find.byType(Icon));
+      expect(icon.color, DeelmarktColors.success);
+    });
+
+    testWidgets('has Semantics label containing title and subtitle', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildCard(title: 'Escrow', subtitle: 'Veilig betalen'),
+      );
+
+      final semantics = tester.getSemantics(find.byType(TrustFeatureCard));
+      expect(semantics.label, contains('Escrow'));
+      expect(semantics.label, contains('Veilig betalen'));
+    });
+
+    testWidgets('renders in dark theme', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: DeelmarktTheme.dark,
+          home: const Scaffold(
+            body: TrustFeatureCard(
+              icon: Icons.lock,
+              title: 'Dark Title',
+              subtitle: 'Dark Sub',
+              iconColor: DeelmarktColors.darkPrimary,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Dark Title'), findsOneWidget);
+      expect(find.text('Dark Sub'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/profile/domain/entities/user_entity_test.dart
+++ b/test/features/profile/domain/entities/user_entity_test.dart
@@ -82,15 +82,130 @@ void main() {
     });
   });
 
+  group('UserEntity copyWith', () {
+    final base = UserEntity(
+      id: 'u1',
+      displayName: 'Alice',
+      kycLevel: KycLevel.level0,
+      createdAt: DateTime(2026, 1, 1),
+      avatarUrl: 'https://example.com/avatar.png',
+      location: 'Amsterdam',
+      badges: const [BadgeType.emailVerified],
+      averageRating: 4.5,
+      reviewCount: 10,
+      responseTimeMinutes: 30,
+    );
+
+    test('returns identical entity when no fields overridden', () {
+      expect(base.copyWith(), equals(base));
+    });
+
+    test('overrides displayName', () {
+      final updated = base.copyWith(displayName: 'Bob');
+      expect(updated.displayName, 'Bob');
+      expect(updated.id, base.id);
+    });
+
+    test('overrides kycLevel', () {
+      final updated = base.copyWith(kycLevel: KycLevel.level4);
+      expect(updated.kycLevel, KycLevel.level4);
+    });
+
+    test('overrides badges', () {
+      final updated = base.copyWith(
+        badges: [BadgeType.trustedSeller, BadgeType.topRated],
+      );
+      expect(updated.badges, [BadgeType.trustedSeller, BadgeType.topRated]);
+    });
+
+    test('overrides multiple fields at once', () {
+      final updated = base.copyWith(
+        displayName: 'Charlie',
+        reviewCount: 99,
+        averageRating: 5.0,
+      );
+      expect(updated.displayName, 'Charlie');
+      expect(updated.reviewCount, 99);
+      expect(updated.averageRating, 5.0);
+      expect(updated.location, base.location);
+    });
+  });
+
   group('KycLevel', () {
     test('has 5 levels', () {
       expect(KycLevel.values.length, equals(5));
+    });
+
+    test('values are in order', () {
+      expect(KycLevel.values, [
+        KycLevel.level0,
+        KycLevel.level1,
+        KycLevel.level2,
+        KycLevel.level3,
+        KycLevel.level4,
+      ]);
     });
   });
 
   group('BadgeType', () {
     test('has 7 types', () {
       expect(BadgeType.values.length, equals(7));
+    });
+
+    test('fromDbList parses valid strings', () {
+      final badges = BadgeType.fromDbList([
+        'emailVerified',
+        'phoneVerified',
+        'trustedSeller',
+      ]);
+      expect(badges, [
+        BadgeType.emailVerified,
+        BadgeType.phoneVerified,
+        BadgeType.trustedSeller,
+      ]);
+    });
+
+    test('fromDbList skips unknown values', () {
+      final badges = BadgeType.fromDbList([
+        'emailVerified',
+        'unknownBadge',
+        'topRated',
+      ]);
+      expect(badges, [BadgeType.emailVerified, BadgeType.topRated]);
+    });
+
+    test('fromDbList skips non-string values', () {
+      final badges = BadgeType.fromDbList([
+        'emailVerified',
+        123,
+        null,
+        'fastResponder',
+      ]);
+      expect(badges, [BadgeType.emailVerified, BadgeType.fastResponder]);
+    });
+
+    test('fromDbList returns empty for empty input', () {
+      expect(BadgeType.fromDbList([]), isEmpty);
+    });
+
+    test('toDbList converts to name strings', () {
+      final result = BadgeType.toDbList([
+        BadgeType.emailVerified,
+        BadgeType.idVerified,
+        BadgeType.newUser,
+      ]);
+      expect(result, ['emailVerified', 'idVerified', 'newUser']);
+    });
+
+    test('roundtrip: toDbList then fromDbList returns same badges', () {
+      final original = [
+        BadgeType.emailVerified,
+        BadgeType.phoneVerified,
+        BadgeType.topRated,
+      ];
+      final dbList = BadgeType.toDbList(original);
+      final restored = BadgeType.fromDbList(dbList);
+      expect(restored, original);
     });
   });
 }


### PR DESCRIPTION
## Summary
- Add missing test files for breakpoints and trust_feature_card
- Expand theme tests to cover all component themes (buttons, cards, nav bar, segmented button, input borders)
- Expand router tests to cover shipping sub-routes and tab routes
- Expand entity tests to cover copyWith methods and BadgeType serialization

Addresses SonarCloud quality gate failure: 68% → targeting ≥80% coverage on new code.

## Test plan
- [x] All 124 affected tests pass locally
- [x] `flutter analyze` — zero warnings
- [x] Pre-commit hooks pass (format, analyze, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)