### PR TITLE
fix(ci): fix sonar coverage exclusion for Supabase repos

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -43,11 +43,11 @@ sonar.issue.ignore.multicriteria.e1.resourceKey=**/domain/entities/**
 # Supabase repos use SupabaseClient with deeply nested generics that can't be
 # mocked with mocktail. These will be covered by integration tests against
 # the real Supabase sandbox. DTOs and providers are fully unit tested.
+# TODO(B-49): Remove **/data/supabase/** after integration test infra is ready
 sonar.coverage.exclusions=\
   lib/core/services/supabase_service.dart,\
   lib/core/services/firebase_service.dart,\
   lib/core/services/firebase_options.dart,\
   lib/core/services/env.dart,\
   lib/main.dart,\
-  # TODO(B-49): Remove after integration test infra is ready
   **/data/supabase/**


### PR DESCRIPTION
## Summary
The `# TODO(B-49)` comment inside the multi-line `sonar.coverage.exclusions` value broke Java properties parsing. The `**/data/supabase/**` glob was never actually excluded, causing 137 lines of unmockable Supabase repository code (0% covered) to drag the quality gate from 93% → 68%.

Fix: move the comment above the property declaration.

## Root cause
```properties
# BROKEN — comment inside continuation breaks parsing
sonar.coverage.exclusions=\
  lib/main.dart,\
  # TODO(B-49): Remove after integration test infra
  **/data/supabase/**

# FIXED — comment outside the value
# TODO(B-49): Remove **/data/supabase/** after integration test infra
sonar.coverage.exclusions=\
  lib/main.dart,\
  **/data/supabase/**
```

## Test plan
- [x] Verified locally: PR #29 new code coverage is 93% with exclusion working correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)