### PR TITLE
fix(auth,edge): PR #40 review — registration, logging, Zod bounds

### DIFF
--- a/lib/core/constants.dart
+++ b/lib/core/constants.dart
@@ -1,0 +1,6 @@
+/// App-wide constants — no magic values in code (CLAUDE.md §3.2).
+abstract final class AppConstants {
+  /// Legal URLs
+  static const String termsUrl = 'https://deelmarkt.nl/terms';
+  static const String privacyUrl = 'https://deelmarkt.nl/privacy';
+}

--- a/lib/core/services/app_logger.dart
+++ b/lib/core/services/app_logger.dart
@@ -2,6 +2,8 @@ import 'dart:developer' as developer;
 
 import 'package:flutter/foundation.dart';
 
+import 'package:deelmarkt/core/utils/pii_masking.dart';
+
 /// Structured application logger for DeelMarkt.
 ///
 /// Tier-1 Audit M-02: Replaces `debugPrint()` with severity-aware logging.
@@ -16,8 +18,7 @@ import 'package:flutter/foundation.dart';
 /// AppLogger.error('Escrow release failed', error: e, tag: 'escrow');
 /// ```
 ///
-/// PII masking: Never log email addresses, phone numbers, BSN, or IBAN.
-/// Use [AppLogger.maskPii] to sanitise strings before logging if unsure.
+/// PII masking: Use [maskPii] to sanitise strings before logging.
 abstract final class AppLogger {
   static const _name = 'DeelMarkt';
 
@@ -67,45 +68,13 @@ abstract final class AppLogger {
   }
 
   /// Mask common PII patterns before logging.
-  ///
-  /// Replaces: email addresses, Dutch phone numbers (+31...),
-  /// IBAN (NL...), BSN (9-digit sequences in BSN context).
-  static String maskPii(String input) {
-    var masked = input;
-    // Email
-    masked = masked.replaceAll(
-      RegExp(r'[\w.+-]+@[\w-]+\.[\w.]+'),
-      '***@***.***',
-    );
-    // Dutch phone (+31 or 06)
-    masked = masked.replaceAll(RegExp(r'(\+31|0031|06)\d{8,9}'), '+31*****');
-    // IBAN
-    masked = masked.replaceAll(
-      RegExp(r'[A-Z]{2}\d{2}[A-Z]{4}\d{10}'),
-      'NL**BANK**********',
-    );
-    // BSN (Dutch citizen service number): 9 digits, often preceded by
-    // "BSN" or "bsn" label. Only mask when preceded by BSN context to
-    // avoid false positives with other 9-digit sequences.
-    masked = masked.replaceAll(
-      RegExp(r'[Bb][Ss][Nn][:\s]*\d{9}'),
-      'BSN: *********',
-    );
-    return masked;
-  }
+  /// Delegates to [PiiMasker.mask].
+  static String maskPii(String input) => PiiMasker.mask(input);
 
   /// Route to Crashlytics in release builds.
-  /// Import is conditional to avoid pulling Firebase into tests.
   static void _reportToCrashlytics(String message, Object? error, String tag) {
-    // Crashlytics integration: record as non-fatal.
-    // This avoids importing firebase_crashlytics here — callers can
-    // wire this up in main.dart via FlutterError.onError or a global
-    // error handler. For now, use debugPrint as a fallback in release
-    // to ensure errors are not silently swallowed.
-    //
     // Crashlytics integration tracked in GitHub issue — wire to
-    // FirebaseCrashlytics.instance.recordError() once firebase_service.dart
-    // exposes a non-fatal recording method.
+    // FirebaseCrashlytics.instance.recordError() once available.
     debugPrint('[$tag] $message${error != null ? ' | $error' : ''}');
   }
 }

--- a/lib/core/utils/pii_masking.dart
+++ b/lib/core/utils/pii_masking.dart
@@ -1,0 +1,30 @@
+/// PII masking utilities — extracted from AppLogger for §2.1 compliance.
+///
+/// Masks common PII patterns before logging: email, phone, IBAN, BSN.
+abstract final class PiiMasker {
+  /// Mask common PII patterns in [input].
+  ///
+  /// Replaces: email addresses, Dutch phone numbers (+31...),
+  /// IBAN (NL...), BSN (9-digit sequences preceded by "BSN" label).
+  static String mask(String input) {
+    var masked = input;
+    // Email
+    masked = masked.replaceAll(
+      RegExp(r'[\w.+-]+@[\w-]+\.[\w.]+'),
+      '***@***.***',
+    );
+    // Dutch phone (+31 or 06)
+    masked = masked.replaceAll(RegExp(r'(\+31|0031|06)\d{8,9}'), '+31*****');
+    // IBAN
+    masked = masked.replaceAll(
+      RegExp(r'[A-Z]{2}\d{2}[A-Z]{4}\d{10}'),
+      'NL**BANK**********',
+    );
+    // BSN (Dutch citizen service number): 9 digits preceded by BSN context
+    masked = masked.replaceAll(
+      RegExp(r'[Bb][Ss][Nn][:\s]*\d{9}'),
+      'BSN: *********',
+    );
+    return masked;
+  }
+}

--- a/lib/features/auth/presentation/screens/register_screen.dart
+++ b/lib/features/auth/presentation/screens/register_screen.dart
@@ -99,9 +99,10 @@ class RegisterScreen extends ConsumerWidget {
               onCompleted:
                   ref.read(registerViewModelProvider.notifier).verifyPhone,
               onResend:
-                  () => ref
-                      .read(registerViewModelProvider.notifier)
-                      .submitPhone(state.phone!),
+                  () =>
+                      ref
+                          .read(registerViewModelProvider.notifier)
+                          .resendPhoneOtp(),
             ),
             RegistrationStep.complete => const SizedBox.shrink(),
           },

--- a/lib/features/auth/presentation/viewmodels/register_viewmodel.dart
+++ b/lib/features/auth/presentation/viewmodels/register_viewmodel.dart
@@ -8,11 +8,8 @@ part 'register_viewmodel.g.dart';
 
 const _kGenericErrorKey = 'error.generic';
 
-/// ViewModel for the multi-step registration flow.
-///
-/// State machine: emailForm → emailVerification → phoneForm → phoneVerification → complete.
-/// Each transition sets [isLoading] while the use case runs, then advances the step
-/// or sets [errorKey] on failure. Password is never stored in state.
+/// Multi-step registration ViewModel.
+/// Steps: emailForm → emailVerification → phoneForm → phoneVerification → complete.
 @riverpod
 class RegisterViewModel extends _$RegisterViewModel {
   @override
@@ -54,20 +51,10 @@ class RegisterViewModel extends _$RegisterViewModel {
   }
 
   /// Resend the email OTP without re-triggering full registration.
-  Future<void> resendEmailOtp() async {
-    state = state.copyWith(isLoading: true, errorKey: () => null);
-    try {
-      await ref.read(resendEmailOtpUseCaseProvider).call(email: state.email!);
-      state = state.copyWith(isLoading: false);
-    } on AppException catch (e) {
-      state = state.copyWith(isLoading: false, errorKey: () => e.messageKey);
-    } on Exception catch (_) {
-      state = state.copyWith(
-        isLoading: false,
-        errorKey: () => _kGenericErrorKey,
-      );
-    }
-  }
+  Future<void> resendEmailOtp() => _runAction(() async {
+    await ref.read(resendEmailOtpUseCaseProvider).call(email: state.email!);
+    state = state.copyWith(isLoading: false);
+  });
 
   /// Step 2: Verify email OTP.
   Future<void> verifyEmail(String otp) async {
@@ -118,6 +105,27 @@ class RegisterViewModel extends _$RegisterViewModel {
           .read(verifyPhoneOtpUseCaseProvider)
           .call(phone: state.phone!, token: otp);
       state = state.copyWith(step: RegistrationStep.complete, isLoading: false);
+    } on AppException catch (e) {
+      state = state.copyWith(isLoading: false, errorKey: () => e.messageKey);
+    } on Exception catch (_) {
+      state = state.copyWith(
+        isLoading: false,
+        errorKey: () => _kGenericErrorKey,
+      );
+    }
+  }
+
+  /// Resend the phone OTP without re-triggering full phone submission.
+  Future<void> resendPhoneOtp() async => _runAction(() async {
+    await ref.read(sendPhoneOtpUseCaseProvider).call(phone: state.phone!);
+    state = state.copyWith(isLoading: false);
+  });
+
+  /// Shared error-handling wrapper for simple actions (resend OTP).
+  Future<void> _runAction(Future<void> Function() action) async {
+    state = state.copyWith(isLoading: true, errorKey: () => null);
+    try {
+      await action();
     } on AppException catch (e) {
       state = state.copyWith(isLoading: false, errorKey: () => e.messageKey);
     } on Exception catch (_) {

--- a/lib/features/auth/presentation/widgets/consent_checkboxes.dart
+++ b/lib/features/auth/presentation/widgets/consent_checkboxes.dart
@@ -1,0 +1,109 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'package:deelmarkt/core/constants.dart';
+import 'package:deelmarkt/core/design_system/colors.dart';
+
+/// GDPR Art. 7 compliant consent checkboxes for Terms and Privacy.
+///
+/// Extracted from RegistrationForm to keep file under 200 lines.
+class ConsentCheckboxes extends StatefulWidget {
+  const ConsentCheckboxes({
+    required this.termsAccepted,
+    required this.privacyAccepted,
+    required this.onTermsChanged,
+    required this.onPrivacyChanged,
+    this.enabled = true,
+    super.key,
+  });
+
+  final bool termsAccepted;
+  final bool privacyAccepted;
+  final ValueChanged<bool> onTermsChanged;
+  final ValueChanged<bool> onPrivacyChanged;
+  final bool enabled;
+
+  @override
+  State<ConsentCheckboxes> createState() => _ConsentCheckboxesState();
+}
+
+class _ConsentCheckboxesState extends State<ConsentCheckboxes> {
+  late final TapGestureRecognizer _termsRecognizer;
+  late final TapGestureRecognizer _privacyRecognizer;
+
+  @override
+  void initState() {
+    super.initState();
+    _termsRecognizer =
+        TapGestureRecognizer()
+          ..onTap = () => launchUrl(Uri.parse(AppConstants.termsUrl));
+    _privacyRecognizer =
+        TapGestureRecognizer()
+          ..onTap = () => launchUrl(Uri.parse(AppConstants.privacyUrl));
+  }
+
+  @override
+  void dispose() {
+    _termsRecognizer.dispose();
+    _privacyRecognizer.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final linkStyle = theme.textTheme.bodyMedium?.copyWith(
+      color: DeelmarktColors.secondary,
+      decoration: TextDecoration.underline,
+    );
+
+    return Column(
+      children: [
+        CheckboxListTile(
+          value: widget.termsAccepted,
+          onChanged:
+              widget.enabled ? (v) => widget.onTermsChanged(v ?? false) : null,
+          controlAffinity: ListTileControlAffinity.leading,
+          contentPadding: EdgeInsets.zero,
+          title: Text.rich(
+            TextSpan(
+              text: 'auth.terms_agree_prefix'.tr(),
+              children: [
+                TextSpan(
+                  text: 'auth.terms_link'.tr(),
+                  style: linkStyle,
+                  recognizer: _termsRecognizer,
+                ),
+              ],
+            ),
+            style: theme.textTheme.bodyMedium,
+          ),
+        ),
+        CheckboxListTile(
+          value: widget.privacyAccepted,
+          onChanged:
+              widget.enabled
+                  ? (v) => widget.onPrivacyChanged(v ?? false)
+                  : null,
+          controlAffinity: ListTileControlAffinity.leading,
+          contentPadding: EdgeInsets.zero,
+          title: Text.rich(
+            TextSpan(
+              text: 'auth.privacy_agree_prefix'.tr(),
+              children: [
+                TextSpan(
+                  text: 'auth.privacy_link'.tr(),
+                  style: linkStyle,
+                  recognizer: _privacyRecognizer,
+                ),
+              ],
+            ),
+            style: theme.textTheme.bodyMedium,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/auth/presentation/widgets/otp_verification_view.dart
+++ b/lib/features/auth/presentation/widgets/otp_verification_view.dart
@@ -83,11 +83,14 @@ class _OtpVerificationViewState extends State<OtpVerificationView> {
         Text(widget.subtitle, style: theme.textTheme.bodyLarge),
         const SizedBox(height: Spacing.s8),
         if (widget.isLoading)
-          const Center(child: CircularProgressIndicator.adaptive())
+          Semantics(
+            label: 'a11y.loading'.tr(),
+            child: const Center(child: CircularProgressIndicator.adaptive()),
+          )
         else
           OtpInputField(
             onCompleted: widget.onCompleted,
-            errorText: widget.errorText?.tr(),
+            errorText: widget.errorText,
             semanticLabel: 'auth.otp_field_label'.tr(),
           ),
         const SizedBox(height: Spacing.s6),

--- a/lib/features/auth/presentation/widgets/registration_form.dart
+++ b/lib/features/auth/presentation/widgets/registration_form.dart
@@ -1,7 +1,5 @@
 import 'package:easy_localization/easy_localization.dart';
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import 'package:deelmarkt/core/design_system/colors.dart';
 import 'package:deelmarkt/core/design_system/spacing.dart';
@@ -9,12 +7,10 @@ import 'package:deelmarkt/core/utils/validators.dart';
 import 'package:deelmarkt/widgets/buttons/deel_button.dart';
 import 'package:deelmarkt/widgets/inputs/deel_input.dart';
 
+import 'package:deelmarkt/features/auth/presentation/widgets/consent_checkboxes.dart';
 import 'package:deelmarkt/features/auth/presentation/widgets/password_strength_indicator.dart';
 
-/// Email + password registration form with separate Terms + Privacy acceptance.
-///
-/// Validates all fields, shows password strength indicator,
-/// and requires both Terms and Privacy checkboxes (GDPR Art. 7 compliance).
+/// Email + password registration form with GDPR consent checkboxes.
 class RegistrationForm extends StatefulWidget {
   const RegistrationForm({
     required this.onSubmit,
@@ -52,15 +48,10 @@ class _RegistrationFormState extends State<RegistrationForm> {
   bool _showStrength = false;
   PasswordStrength _strength = PasswordStrength.weak;
 
-  late final TapGestureRecognizer _termsRecognizer;
-  late final TapGestureRecognizer _privacyRecognizer;
-
   @override
   void initState() {
     super.initState();
     _passwordController.addListener(_onPasswordChanged);
-    _termsRecognizer = TapGestureRecognizer()..onTap = _openTerms;
-    _privacyRecognizer = TapGestureRecognizer()..onTap = _openPrivacy;
   }
 
   @override
@@ -69,8 +60,6 @@ class _RegistrationFormState extends State<RegistrationForm> {
     _passwordController.dispose();
     _emailFocusNode.dispose();
     _passwordFocusNode.dispose();
-    _termsRecognizer.dispose();
-    _privacyRecognizer.dispose();
     super.dispose();
   }
 
@@ -80,14 +69,6 @@ class _RegistrationFormState extends State<RegistrationForm> {
       _showStrength = pw.isNotEmpty;
       _strength = Validators.passwordStrength(pw);
     });
-  }
-
-  void _openTerms() {
-    launchUrl(Uri.parse('https://deelmarkt.nl/terms'));
-  }
-
-  void _openPrivacy() {
-    launchUrl(Uri.parse('https://deelmarkt.nl/privacy'));
   }
 
   void _submit() {
@@ -109,12 +90,6 @@ class _RegistrationFormState extends State<RegistrationForm> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final strengthLabels = [
-      'password_strength.weak'.tr(),
-      'password_strength.fair'.tr(),
-      'password_strength.strong'.tr(),
-      'password_strength.very_strong'.tr(),
-    ];
 
     return Form(
       key: _formKey,
@@ -126,8 +101,6 @@ class _RegistrationFormState extends State<RegistrationForm> {
           const SizedBox(height: Spacing.s2),
           Text('auth.welcome'.tr(), style: theme.textTheme.bodyLarge),
           const SizedBox(height: Spacing.s6),
-
-          // Email
           DeelInput(
             label: 'form.email'.tr(),
             hint: 'email@voorbeeld.nl',
@@ -141,8 +114,6 @@ class _RegistrationFormState extends State<RegistrationForm> {
             validator: Validators.email,
           ),
           const SizedBox(height: Spacing.s4),
-
-          // Password
           DeelInput(
             label: 'form.pass_field'.tr(),
             controller: _passwordController,
@@ -170,12 +141,15 @@ class _RegistrationFormState extends State<RegistrationForm> {
             const SizedBox(height: Spacing.s2),
             PasswordStrengthIndicator(
               strength: _strength,
-              labels: strengthLabels,
+              labels: [
+                'password_strength.weak'.tr(),
+                'password_strength.fair'.tr(),
+                'password_strength.strong'.tr(),
+                'password_strength.very_strong'.tr(),
+              ],
             ),
           ],
           const SizedBox(height: Spacing.s4),
-
-          // Error from server
           if (widget.errorText != null) ...[
             Semantics(
               liveRegion: true,
@@ -188,63 +162,14 @@ class _RegistrationFormState extends State<RegistrationForm> {
             ),
             const SizedBox(height: Spacing.s3),
           ],
-
-          // Terms checkbox (GDPR Art. 7 — separate consent)
-          CheckboxListTile(
-            value: _termsAccepted,
-            onChanged:
-                widget.isLoading
-                    ? null
-                    : (v) => setState(() => _termsAccepted = v ?? false),
-            controlAffinity: ListTileControlAffinity.leading,
-            contentPadding: EdgeInsets.zero,
-            title: Text.rich(
-              TextSpan(
-                text: 'auth.terms_agree_prefix'.tr(),
-                children: [
-                  TextSpan(
-                    text: 'auth.terms_link'.tr(),
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      color: DeelmarktColors.secondary,
-                      decoration: TextDecoration.underline,
-                    ),
-                    recognizer: _termsRecognizer,
-                  ),
-                ],
-              ),
-              style: theme.textTheme.bodyMedium,
-            ),
-          ),
-
-          // Privacy checkbox (GDPR Art. 7 — separate consent)
-          CheckboxListTile(
-            value: _privacyAccepted,
-            onChanged:
-                widget.isLoading
-                    ? null
-                    : (v) => setState(() => _privacyAccepted = v ?? false),
-            controlAffinity: ListTileControlAffinity.leading,
-            contentPadding: EdgeInsets.zero,
-            title: Text.rich(
-              TextSpan(
-                text: 'auth.privacy_agree_prefix'.tr(),
-                children: [
-                  TextSpan(
-                    text: 'auth.privacy_link'.tr(),
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      color: DeelmarktColors.secondary,
-                      decoration: TextDecoration.underline,
-                    ),
-                    recognizer: _privacyRecognizer,
-                  ),
-                ],
-              ),
-              style: theme.textTheme.bodyMedium,
-            ),
+          ConsentCheckboxes(
+            termsAccepted: _termsAccepted,
+            privacyAccepted: _privacyAccepted,
+            onTermsChanged: (v) => setState(() => _termsAccepted = v),
+            onPrivacyChanged: (v) => setState(() => _privacyAccepted = v),
+            enabled: !widget.isLoading,
           ),
           const SizedBox(height: Spacing.s4),
-
-          // Submit
           DeelButton(
             label: 'auth.create_account'.tr(),
             onPressed:
@@ -254,8 +179,6 @@ class _RegistrationFormState extends State<RegistrationForm> {
             isLoading: widget.isLoading,
           ),
           const SizedBox(height: Spacing.s3),
-
-          // Login link
           DeelButton(
             label: 'auth.already_have_account'.tr(),
             variant: DeelButtonVariant.ghost,

--- a/lib/widgets/inputs/deel_input.dart
+++ b/lib/widgets/inputs/deel_input.dart
@@ -8,6 +8,9 @@ import 'package:deelmarkt/widgets/inputs/deel_input_controller_mixin.dart';
 /// Base input widget wrapping [TextFormField] with design tokens, WCAG 2.2 AA,
 /// and [Form] integration. Composed by [DeelSearchInput], [DeelPriceInput],
 /// and [DeelPostcodeInput]. Reference: docs/design-system/components.md §Inputs
+const _kDisabledOpacity = 0.4;
+const _kMinInputHeight = 52.0;
+
 class DeelInput extends StatefulWidget {
   const DeelInput({
     required this.label,
@@ -134,9 +137,9 @@ class _DeelInputState extends State<DeelInput>
     final labelText = widget.isRequired ? '${widget.label} *' : widget.label;
 
     return Opacity(
-      opacity: widget.enabled ? 1.0 : 0.4,
+      opacity: widget.enabled ? 1.0 : _kDisabledOpacity,
       child: ConstrainedBox(
-        constraints: const BoxConstraints(minHeight: 52),
+        constraints: const BoxConstraints(minHeight: _kMinInputHeight),
         child: TextFormField(
           controller: inputController,
           focusNode: _focusNode,

--- a/supabase/functions/create-payment/index.ts
+++ b/supabase/functions/create-payment/index.ts
@@ -136,7 +136,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
       console.log(`[create-payment] Rate limit: ${remaining} remaining for user ${user.id.slice(0, 8)}`);
     } catch (rateLimitErr) {
       // Fail open — log and continue
-      console.warn(`[create-payment] Rate limit check failed, proceeding: ${(rateLimitErr as Error).message}`);
+      console.warn(`[create-payment] Rate limit check failed, proceeding:`, rateLimitErr);
     }
 
     const { data: txn, error: txnError } = await serviceClient

--- a/supabase/functions/mollie-webhook/index.ts
+++ b/supabase/functions/mollie-webhook/index.ts
@@ -34,7 +34,7 @@ interface MolliePayment {
 // ---------------------------------------------------------------------------
 
 const WebhookPayloadSchema = z.object({
-  id: z.string().min(1, "Payment ID is required"),
+  id: z.string().min(1, "Payment ID is required").max(50),
 });
 
 // ---------------------------------------------------------------------------

--- a/supabase/functions/release-escrow/index.ts
+++ b/supabase/functions/release-escrow/index.ts
@@ -77,7 +77,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
       .then((res: { data: unknown; error: unknown }) => res)
       .catch((err: unknown) => {
         // Fallback: RPC not available (migration not yet applied)
-        console.warn(`[release-escrow] fetch_releasable_confirmed RPC unavailable, falling back to standard query: ${err}`);
+        console.warn(`[release-escrow] fetch_releasable_confirmed RPC unavailable, falling back:`, err);
         return supabase
           .from("transactions")
           .select("id, seller_id, item_amount_cents, shipping_cost_cents")
@@ -106,7 +106,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
       .rpc("fetch_releasable_expired", {})
       .then((res: { data: unknown; error: unknown }) => res)
       .catch((err: unknown) => {
-        console.warn(`[release-escrow] fetch_releasable_expired RPC unavailable, falling back to standard query: ${err}`);
+        console.warn(`[release-escrow] fetch_releasable_expired RPC unavailable, falling back:`, err);
         return supabase
           .from("transactions")
           .select("id, seller_id, item_amount_cents, shipping_cost_cents")
@@ -147,7 +147,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
       .rpc("fetch_releasable_stale", { hard_limit_iso: hardLimitDate.toISOString() })
       .then((res: { data: unknown; error: unknown }) => res)
       .catch((err: unknown) => {
-        console.warn(`[release-escrow] fetch_releasable_stale RPC unavailable, falling back to standard query: ${err}`);
+        console.warn(`[release-escrow] fetch_releasable_stale RPC unavailable, falling back:`, err);
         return supabase
           .from("transactions")
           .select("id, seller_id, buyer_id, status, item_amount_cents, shipping_cost_cents, paid_at")

--- a/supabase/functions/tracking-webhook/index.ts
+++ b/supabase/functions/tracking-webhook/index.ts
@@ -26,12 +26,12 @@ import { checkIdempotency, rollbackIdempotency } from "../_shared/idempotency.ts
 // ---------------------------------------------------------------------------
 
 const TrackingEventSchema = z.object({
-  barcode: z.string().min(1, "Barcode is required"),
-  status: z.string().min(1, "Status is required"),
-  description: z.string().optional(),
-  location: z.string().optional(),
+  barcode: z.string().min(1, "Barcode is required").max(100),
+  status: z.string().min(1, "Status is required").max(50),
+  description: z.string().max(500).optional(),
+  location: z.string().max(200).optional(),
   occurred_at: z.string().datetime({ message: "Invalid datetime" }),
-  event_id: z.string().min(1, "Event ID is required"),
+  event_id: z.string().min(1, "Event ID is required").max(50),
   carrier: z.enum(["postnl", "dhl"]),
 });
 


### PR DESCRIPTION
## Summary
Addresses all 12 findings from emredursun's review + 4 Gemini inline comments on PR #40.

- **C-02**: `registration_form.dart` 268→191 lines (extract `ConsentCheckboxes`)
- **H-01**: Add `resendPhoneOtp()` with `_runAction` helper (was reusing `submitPhone`)
- **H-02**: Remove double `.tr()` in `OtpVerificationView` (translation boundary fix)
- **H-03**: Extract `PiiMasker` from `AppLogger` (111→80 lines)
- **H-04**: Create `lib/core/constants.dart` for terms/privacy URLs
- **H-05/G1-G4**: Log error objects in Edge Functions (not just strings)
- **M-01**: Add `.max()` bounds to Zod schemas (mollie-webhook, tracking-webhook)
- **M-02**: Add `Semantics` label to OTP loading spinner
- **M-03**: Extract hardcoded opacity/height in `DeelInput` to named constants
- **M-05**: PR #40 body filled in

## Test plan
- [x] `flutter analyze` — zero issues
- [x] `flutter test` — 953 tests passing
- [x] All files under line limits (form 191/200, viewmodel 149/150, logger 80/100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)