### PR TITLE
feat(trust): R-37 — account sanctions + appeal/reinstatement flow

### DIFF
--- a/assets/l10n/en-US.json
+++ b/assets/l10n/en-US.json
@@ -754,5 +754,36 @@
     "month_ago": "1 month ago",
     "months_ago": "{n} months ago",
     "year_ago": "1 year ago"
+  },
+  "sanction": {
+    "type": {
+      "warning": "Warning",
+      "suspension": "Suspension",
+      "ban": "Ban"
+    },
+    "screen": {
+      "title": "Account suspended",
+      "reason_label": "Reason",
+      "expires_label": "Suspended until",
+      "permanent": "Permanent",
+      "appeal_title": "Submit an appeal",
+      "appeal_hint": "Explain why you believe this decision is incorrect (max 1000 characters)",
+      "appeal_submit": "Submit appeal",
+      "appeal_submitted_title": "Appeal submitted",
+      "appeal_submitted_body": "We will review your appeal within 72 hours.",
+      "appeal_pending_title": "Appeal under review",
+      "appeal_pending_body": "Your appeal is being reviewed. We will notify you of the decision within 72 hours.",
+      "appeal_upheld_title": "Appeal upheld",
+      "appeal_upheld_body": "Your appeal was reviewed and the decision stands.",
+      "appeal_overturned_title": "Account reinstated",
+      "appeal_overturned_body": "Your appeal was accepted. Your account has been fully restored.",
+      "appeal_window_closed": "The 14-day appeal window for this sanction has closed.",
+      "appeal_not_eligible": "Warnings cannot be appealed.",
+      "contact_support": "Contact support"
+    },
+    "a11y": {
+      "sanction_icon": "Account suspended icon",
+      "appeal_form": "Appeal form"
+    }
   }
 }

--- a/assets/l10n/nl-NL.json
+++ b/assets/l10n/nl-NL.json
@@ -754,5 +754,36 @@
     "month_ago": "1 maand geleden",
     "months_ago": "{n} maanden geleden",
     "year_ago": "1 jaar geleden"
+  },
+  "sanction": {
+    "type": {
+      "warning": "Waarschuwing",
+      "suspension": "Schorsing",
+      "ban": "Verbanning"
+    },
+    "screen": {
+      "title": "Account geschorst",
+      "reason_label": "Reden",
+      "expires_label": "Geschorst tot",
+      "permanent": "Permanent",
+      "appeal_title": "Bezwaar indienen",
+      "appeal_hint": "Leg uit waarom je denkt dat deze beslissing onjuist is (max. 1000 tekens)",
+      "appeal_submit": "Bezwaar indienen",
+      "appeal_submitted_title": "Bezwaar ingediend",
+      "appeal_submitted_body": "We beoordelen je bezwaar binnen 72 uur.",
+      "appeal_pending_title": "Bezwaar in behandeling",
+      "appeal_pending_body": "Je bezwaar wordt beoordeeld. We sturen je een bericht zodra er een beslissing is genomen.",
+      "appeal_upheld_title": "Bezwaar afgewezen",
+      "appeal_upheld_body": "Je bezwaar is beoordeeld en de beslissing blijft van kracht.",
+      "appeal_overturned_title": "Account hersteld",
+      "appeal_overturned_body": "Je bezwaar is geaccepteerd. Je account is volledig hersteld.",
+      "appeal_window_closed": "De bezwaartermijn van 14 dagen voor deze sanctie is verlopen.",
+      "appeal_not_eligible": "Waarschuwingen kunnen niet worden aangevochten.",
+      "contact_support": "Neem contact op met support"
+    },
+    "a11y": {
+      "sanction_icon": "Pictogram account geschorst",
+      "appeal_form": "Bezwaarformulier"
+    }
   }
 }

--- a/docs/SPRINT-PLAN.md
+++ b/docs/SPRINT-PLAN.md
@@ -247,7 +247,8 @@ The agent will:
 - [x] `R-34` FCM push notification on new message — delivered on iOS + Android *(PR #94)*
 - [x] `R-35` E06 scam detection Edge Function — flagged/clean in <1s
 - [x] `R-36` Reviews table + blind review logic — hidden until both submit *(PR #98)*
-- [ ] `R-37` Account suspension/appeal tables + flow — suspend/appeal/reinstate *(branch: `feature/reso-E06-r37-suspension`)*
+- [ ] `R-37` Account suspension/appeal tables + flow — suspend/appeal/reinstate *(branch: `feature/reso-E06-r37-suspension`)* **[backend-only — UI tracked as P-53]**
+  > **Email follow-up:** Sanction email notifications are not included in R-37. Email delivery via Supabase SMTP / Resend will be tracked as a separate task once the email provider is configured.
 - [ ] `R-38` DSA notice-and-action reporting table — 24hr SLA tracked
 
 ### belengaz `[B]` — Message Data Layer + Monitoring + Security
@@ -292,6 +293,7 @@ The agent will:
 - [x] `P-50` GoRouter auth guard + splash screen + `/onboarding` route ✅ PR #14
 - [x] `P-51` Mock data layer (5 entities + 4 repository interfaces + 4 mock implementations) ✅ PR #14
 - [x] `P-52` Web error boundary + font loading strategy ✅ PR #14
+- [ ] `P-53` Suspension gate + appeal screen — auth guard shows suspension screen (type/reason/expires), appeal form with 14-day window indicator *(blocked by R-37 merge)*
 
 ---
 

--- a/docs/SPRINT-PLAN.md
+++ b/docs/SPRINT-PLAN.md
@@ -72,18 +72,18 @@ The agent will:
 - [x] `B-03` Set up Cloudinary account — API key in Supabase Vault, test upload works
 - [x] `B-04` Create GitHub Actions CI workflow — lint, analyze, test, CVE scan on PR
 - [ ] `B-05` Set up Codemagic — iOS (TestFlight) + Android (Play internal) builds ⚠️ Needs Apple Dev + Google Play accounts
-  > **Android build notu:** CI'da fat APK kullanıyoruz (sadece "build ediyor mu" kontrolü). Production build'de mutlaka `--split-per-abi` veya App Bundle kullanılacak:
+  > **Android build note:** CI uses a fat APK (build-only check). Production builds must use `--split-per-abi` or App Bundle:
   > ```
-  > # Tercih 1 — App Bundle (Play Store otomatik split eder, en iyi seçenek):
+  > # Option 1 — App Bundle (Play Store splits automatically, recommended):
   > flutter build appbundle --release --obfuscate --split-debug-info=build/debug-info
   >
-  > # Tercih 2 — Split APK (3 ayrı APK üretir):
+  > # Option 2 — Split APK (produces 3 separate APKs):
   > flutter build apk --release --split-per-abi --obfuscate --split-debug-info=build/debug-info
-  > # → app-armeabi-v7a-release.apk (~20MB) — eski telefonlar
-  > # → app-arm64-v8a-release.apk (~22MB) — modern telefonlar (%95 kullanıcı)
-  > # → app-x86_64-release.apk (~23MB) — emülatörler
+  > # → app-armeabi-v7a-release.apk (~20 MB) — older devices
+  > # → app-arm64-v8a-release.apk  (~22 MB) — modern devices (95% of users)
+  > # → app-x86_64-release.apk     (~23 MB) — emulators
   > ```
-  > Kullanıcı fat APK yerine sadece kendi cihazına uygun olanı indirir (~22MB vs 62MB).
+  > Users download only the slice for their device (~22 MB instead of ~62 MB fat APK).
 - [x] `B-06` Host AASA file on Cloudflare — valid JSON at `/.well-known/apple-app-site-association`
 - [x] `B-07` Host `assetlinks.json` for Android — accessible at correct URL
 - [x] `B-08` Implement GoRouter deep link handler — notification tap opens correct screen

--- a/docs/SPRINT-PLAN.md
+++ b/docs/SPRINT-PLAN.md
@@ -72,6 +72,18 @@ The agent will:
 - [x] `B-03` Set up Cloudinary account — API key in Supabase Vault, test upload works
 - [x] `B-04` Create GitHub Actions CI workflow — lint, analyze, test, CVE scan on PR
 - [ ] `B-05` Set up Codemagic — iOS (TestFlight) + Android (Play internal) builds ⚠️ Needs Apple Dev + Google Play accounts
+  > **Android build notu:** CI'da fat APK kullanıyoruz (sadece "build ediyor mu" kontrolü). Production build'de mutlaka `--split-per-abi` veya App Bundle kullanılacak:
+  > ```
+  > # Tercih 1 — App Bundle (Play Store otomatik split eder, en iyi seçenek):
+  > flutter build appbundle --release --obfuscate --split-debug-info=build/debug-info
+  >
+  > # Tercih 2 — Split APK (3 ayrı APK üretir):
+  > flutter build apk --release --split-per-abi --obfuscate --split-debug-info=build/debug-info
+  > # → app-armeabi-v7a-release.apk (~20MB) — eski telefonlar
+  > # → app-arm64-v8a-release.apk (~22MB) — modern telefonlar (%95 kullanıcı)
+  > # → app-x86_64-release.apk (~23MB) — emülatörler
+  > ```
+  > Kullanıcı fat APK yerine sadece kendi cihazına uygun olanı indirir (~22MB vs 62MB).
 - [x] `B-06` Host AASA file on Cloudflare — valid JSON at `/.well-known/apple-app-site-association`
 - [x] `B-07` Host `assetlinks.json` for Android — accessible at correct URL
 - [x] `B-08` Implement GoRouter deep link handler — notification tap opens correct screen
@@ -235,7 +247,7 @@ The agent will:
 - [x] `R-34` FCM push notification on new message — delivered on iOS + Android *(PR #94)*
 - [x] `R-35` E06 scam detection Edge Function — flagged/clean in <1s
 - [x] `R-36` Reviews table + blind review logic — hidden until both submit *(PR #98)*
-- [ ] `R-37` Account suspension/appeal tables + flow — suspend/appeal/reinstate
+- [ ] `R-37` Account suspension/appeal tables + flow — suspend/appeal/reinstate *(branch: `feature/reso-E06-r37-suspension`)*
 - [ ] `R-38` DSA notice-and-action reporting table — 24hr SLA tracked
 
 ### belengaz `[B]` — Message Data Layer + Monitoring + Security

--- a/lib/core/services/repository_providers.dart
+++ b/lib/core/services/repository_providers.dart
@@ -10,12 +10,15 @@ import 'package:deelmarkt/features/messages/data/mock/mock_message_repository.da
 import 'package:deelmarkt/features/messages/data/supabase/supabase_message_repository.dart';
 import 'package:deelmarkt/features/messages/domain/repositories/message_repository.dart';
 import 'package:deelmarkt/features/profile/data/mock/mock_review_repository.dart';
+import 'package:deelmarkt/features/profile/data/mock/mock_sanction_repository.dart';
 import 'package:deelmarkt/features/profile/data/mock/mock_settings_repository.dart';
 import 'package:deelmarkt/features/profile/data/supabase/supabase_review_repository.dart';
+import 'package:deelmarkt/features/profile/data/supabase/supabase_sanction_repository.dart';
 import 'package:deelmarkt/features/profile/data/supabase/supabase_settings_repository.dart';
 import 'package:deelmarkt/features/profile/data/mock/mock_user_repository.dart';
 import 'package:deelmarkt/features/profile/data/supabase/supabase_user_repository.dart';
 import 'package:deelmarkt/features/profile/domain/repositories/review_repository.dart';
+import 'package:deelmarkt/features/profile/domain/repositories/sanction_repository.dart';
 import 'package:deelmarkt/features/profile/domain/repositories/settings_repository.dart';
 import 'package:deelmarkt/features/profile/domain/repositories/user_repository.dart';
 import 'package:deelmarkt/features/transaction/data/mock/mock_transaction_repository.dart';
@@ -92,4 +95,14 @@ final messageRepositoryProvider = Provider<MessageRepository>((ref) {
   final useMock = ref.watch(useMockDataProvider);
   if (useMock) return MockMessageRepository();
   return SupabaseMessageRepository(ref.watch(supabaseClientProvider));
+});
+
+/// Sanction repository — mock or Supabase based on [useMockDataProvider].
+///
+/// Provides read access to [account_sanctions] and the [submit_appeal] RPC.
+/// All write operations (issuance, decisions) are service_role-only (R-37).
+final sanctionRepositoryProvider = Provider<SanctionRepository>((ref) {
+  final useMock = ref.watch(useMockDataProvider);
+  if (useMock) return MockSanctionRepository();
+  return SupabaseSanctionRepository(ref.watch(supabaseClientProvider));
 });

--- a/lib/features/profile/data/dto/sanction_dto.dart
+++ b/lib/features/profile/data/dto/sanction_dto.dart
@@ -53,7 +53,7 @@ class SanctionDto {
       userId: userId,
       type: type,
       reason: reason,
-      createdAt: DateTime.tryParse(createdAtRaw) ?? DateTime.now(),
+      createdAt: DateTime.parse(createdAtRaw),
       expiresAt: _parseDate(json['expires_at']),
       appealedAt: _parseDate(json['appealed_at']),
       appealBody: json['appeal_body'] as String?,

--- a/lib/features/profile/data/dto/sanction_dto.dart
+++ b/lib/features/profile/data/dto/sanction_dto.dart
@@ -1,0 +1,83 @@
+import 'package:deelmarkt/features/profile/domain/entities/sanction_entity.dart';
+
+/// Maps raw Supabase JSON rows from [account_sanctions] to [SanctionEntity].
+///
+/// Reference: docs/SPRINT-PLAN.md R-37
+class SanctionDto {
+  SanctionDto._();
+
+  static SanctionEntity fromJson(Map<String, dynamic> json) {
+    final id = json['id'] as String?;
+    final userId = json['user_id'] as String?;
+    final typeRaw = json['type'] as String?;
+    final reason = json['reason'] as String?;
+    final createdAtRaw = json['created_at'] as String?;
+
+    if (id == null ||
+        id.isEmpty ||
+        userId == null ||
+        userId.isEmpty ||
+        typeRaw == null ||
+        reason == null ||
+        reason.isEmpty ||
+        createdAtRaw == null) {
+      throw const FormatException(
+        'SanctionDto.fromJson: missing required fields',
+      );
+    }
+
+    final type = SanctionType.values.firstWhere(
+      (e) => e.name == typeRaw,
+      orElse:
+          () =>
+              throw FormatException(
+                'SanctionDto.fromJson: unknown type: $typeRaw',
+              ),
+    );
+
+    final decisionRaw = json['appeal_decision'] as String?;
+    final appealDecision =
+        decisionRaw == null
+            ? null
+            : AppealDecision.values.firstWhere(
+              (e) => e.name == decisionRaw,
+              orElse:
+                  () =>
+                      throw FormatException(
+                        'SanctionDto.fromJson: unknown appeal_decision: $decisionRaw',
+                      ),
+            );
+
+    return SanctionEntity(
+      id: id,
+      userId: userId,
+      type: type,
+      reason: reason,
+      createdAt: DateTime.tryParse(createdAtRaw) ?? DateTime.now(),
+      expiresAt: _parseDate(json['expires_at']),
+      appealedAt: _parseDate(json['appealed_at']),
+      appealBody: json['appeal_body'] as String?,
+      appealDecision: appealDecision,
+      resolvedAt: _parseDate(json['resolved_at']),
+    );
+  }
+
+  static DateTime? _parseDate(dynamic raw) {
+    if (raw is! String) return null;
+    return DateTime.tryParse(raw);
+  }
+
+  /// Parses a list, silently skipping malformed entries.
+  static List<SanctionEntity> fromJsonList(List<dynamic> list) {
+    final result = <SanctionEntity>[];
+    for (final item in list) {
+      if (item is! Map<String, dynamic>) continue;
+      try {
+        result.add(fromJson(item));
+      } on FormatException {
+        continue;
+      }
+    }
+    return result;
+  }
+}

--- a/lib/features/profile/data/dto/sanction_dto.dart
+++ b/lib/features/profile/data/dto/sanction_dto.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import 'package:deelmarkt/features/profile/domain/entities/sanction_entity.dart';
 
 /// Maps raw Supabase JSON rows from [account_sanctions] to [SanctionEntity].
@@ -74,7 +76,8 @@ class SanctionDto {
       if (item is! Map<String, dynamic>) continue;
       try {
         result.add(fromJson(item));
-      } on FormatException {
+      } on FormatException catch (e) {
+        debugPrint('SanctionDto.fromJsonList: skipping malformed row — $e');
         continue;
       }
     }

--- a/lib/features/profile/data/mock/mock_sanction_repository.dart
+++ b/lib/features/profile/data/mock/mock_sanction_repository.dart
@@ -1,0 +1,48 @@
+import 'package:deelmarkt/features/profile/domain/entities/sanction_entity.dart';
+import 'package:deelmarkt/features/profile/domain/repositories/sanction_repository.dart';
+
+/// Mock implementation of [SanctionRepository] for development and testing.
+///
+/// Returns no active sanction by default so the app is fully accessible in
+/// dev/mock mode. Override [activeForUserId] in tests to simulate a suspension.
+class MockSanctionRepository implements SanctionRepository {
+  MockSanctionRepository({this.activeForUserId});
+
+  /// If set, [getActiveSanction] returns a mock suspension for this user ID.
+  final String? activeForUserId;
+
+  @override
+  Future<SanctionEntity?> getActiveSanction(String userId) async {
+    if (activeForUserId != null && userId == activeForUserId) {
+      return SanctionEntity(
+        id: 'mock-sanction-001',
+        userId: userId,
+        type: SanctionType.suspension,
+        reason: 'Mock suspension — dev/test only',
+        createdAt: DateTime.now().subtract(const Duration(days: 1)),
+        expiresAt: DateTime.now().add(const Duration(days: 6)),
+      );
+    }
+    return null;
+  }
+
+  @override
+  Future<List<SanctionEntity>> getAll(String userId) async => [];
+
+  @override
+  Future<SanctionEntity> submitAppeal(
+    String sanctionId,
+    String appealBody,
+  ) async {
+    return SanctionEntity(
+      id: sanctionId,
+      userId: activeForUserId ?? 'mock-user',
+      type: SanctionType.suspension,
+      reason: 'Mock suspension — dev/test only',
+      createdAt: DateTime.now().subtract(const Duration(days: 1)),
+      expiresAt: DateTime.now().add(const Duration(days: 6)),
+      appealedAt: DateTime.now(),
+      appealBody: appealBody,
+    );
+  }
+}

--- a/lib/features/profile/data/supabase/supabase_sanction_repository.dart
+++ b/lib/features/profile/data/supabase/supabase_sanction_repository.dart
@@ -1,0 +1,86 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:deelmarkt/features/profile/data/dto/sanction_dto.dart';
+import 'package:deelmarkt/features/profile/domain/entities/sanction_entity.dart';
+import 'package:deelmarkt/features/profile/domain/repositories/sanction_repository.dart';
+
+/// Supabase implementation of [SanctionRepository].
+///
+/// All write operations (issuance, appeal decisions, reinstatement) are
+/// service_role-only at the DB level — this repository only exposes the
+/// read path and the [submitAppeal] RPC for the authenticated user.
+///
+/// Reference: docs/epics/E06-trust-moderation.md §Account Suspension & Recovery
+/// Reference: docs/SPRINT-PLAN.md R-37
+class SupabaseSanctionRepository implements SanctionRepository {
+  const SupabaseSanctionRepository(this._client);
+
+  final SupabaseClient _client;
+
+  static const _table = 'account_sanctions';
+
+  /// Returns the current active suspension or ban via the server-side
+  /// [get_active_sanction] RPC. Using an RPC avoids client-side clock
+  /// manipulation (same pattern as [submit_review] in R-36).
+  @override
+  Future<SanctionEntity?> getActiveSanction(String userId) async {
+    try {
+      final response = await _client.rpc(
+        'get_active_sanction',
+        params: {'p_user_id': userId},
+      );
+
+      final rows = response as List<dynamic>;
+      if (rows.isEmpty) return null;
+
+      return SanctionDto.fromJson(rows.first as Map<String, dynamic>);
+    } on PostgrestException catch (e) {
+      throw Exception(
+        'Failed to fetch active sanction for user $userId: ${e.message}',
+      );
+    }
+  }
+
+  @override
+  Future<List<SanctionEntity>> getAll(String userId) async {
+    try {
+      final response = await _client
+          .from(_table)
+          .select()
+          .eq('user_id', userId)
+          .order('created_at', ascending: false);
+
+      return SanctionDto.fromJsonList(response as List<dynamic>);
+    } on PostgrestException catch (e) {
+      throw Exception(
+        'Failed to fetch sanctions for user $userId: ${e.message}',
+      );
+    }
+  }
+
+  @override
+  Future<SanctionEntity> submitAppeal(
+    String sanctionId,
+    String appealBody,
+  ) async {
+    final userId = _client.auth.currentUser?.id;
+    if (userId == null) {
+      throw Exception('Cannot submit appeal: user is not authenticated');
+    }
+
+    try {
+      final response = await _client.rpc(
+        'submit_appeal',
+        params: {'p_sanction_id': sanctionId, 'p_appeal_body': appealBody},
+      );
+
+      final rows = response as List<dynamic>;
+      if (rows.isEmpty) {
+        throw Exception('submit_appeal RPC returned no rows');
+      }
+      return SanctionDto.fromJson(rows.first as Map<String, dynamic>);
+    } on PostgrestException catch (e) {
+      throw Exception('Failed to submit appeal: ${e.message}');
+    }
+  }
+}

--- a/lib/features/profile/domain/entities/sanction_entity.dart
+++ b/lib/features/profile/domain/entities/sanction_entity.dart
@@ -1,0 +1,95 @@
+/// Account sanction types. Matches the `sanction_type` DB enum (migration R-37).
+///
+/// Only [suspension] and [ban] block account access.
+/// [warning] is informational only — the user can still transact.
+enum SanctionType { warning, suspension, ban }
+
+/// Moderator's decision on a user's appeal.
+/// Matches the `appeal_decision_t` DB enum (migration R-37).
+enum AppealDecision {
+  /// Appeal reviewed — sanction stands.
+  upheld,
+
+  /// Appeal accepted — sanction lifted, account reinstated.
+  overturned,
+}
+
+/// A platform-issued sanction against a user account.
+///
+/// Sanctions flow: issued (service_role) → [SanctionType.warning] stays
+/// informational; [SanctionType.suspension]/[SanctionType.ban] block access
+/// until [expiresAt] passes or appeal is [AppealDecision.overturned].
+///
+/// Reference: docs/epics/E06-trust-moderation.md §Account Suspension & Recovery
+/// Reference: docs/SPRINT-PLAN.md R-37
+class SanctionEntity {
+  const SanctionEntity({
+    required this.id,
+    required this.userId,
+    required this.type,
+    required this.reason,
+    required this.createdAt,
+    this.expiresAt,
+    this.appealedAt,
+    this.appealBody,
+    this.appealDecision,
+    this.resolvedAt,
+  });
+
+  final String id;
+  final String userId;
+  final SanctionType type;
+
+  /// Plain-language reason for the sanction. Never a vague "policy violation".
+  final String reason;
+
+  final DateTime createdAt;
+
+  /// Null for permanent bans. Set for temporary suspensions (e.g. 7/14/30 days).
+  final DateTime? expiresAt;
+
+  /// When the user submitted their appeal. Null if no appeal yet.
+  final DateTime? appealedAt;
+
+  /// The appeal text submitted by the user.
+  final String? appealBody;
+
+  /// Moderator's final decision. Null while pending or if not appealed.
+  final AppealDecision? appealDecision;
+
+  /// When the appeal was resolved by a moderator.
+  final DateTime? resolvedAt;
+
+  /// Whether this sanction currently blocks account access.
+  ///
+  /// [SanctionType.warning] never blocks. A sanction stops being active if
+  /// it was overturned on appeal or has naturally expired.
+  bool get isActive {
+    if (type == SanctionType.warning) return false;
+    if (appealDecision == AppealDecision.overturned) return false;
+    if (expiresAt != null && expiresAt!.isBefore(DateTime.now())) return false;
+    return true;
+  }
+
+  /// Whether the user can still submit (or revise) an appeal.
+  ///
+  /// Conditions: suspension/ban, no final decision yet, within 14-day window.
+  bool get canAppeal {
+    if (type == SanctionType.warning) return false;
+    if (appealDecision != null) return false;
+    return DateTime.now().difference(createdAt).inDays < 14;
+  }
+
+  /// True when the user has submitted an appeal but no decision has been made.
+  bool get isAppealPending => appealedAt != null && appealDecision == null;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SanctionEntity &&
+          runtimeType == other.runtimeType &&
+          id == other.id;
+
+  @override
+  int get hashCode => id.hashCode;
+}

--- a/lib/features/profile/domain/repositories/sanction_repository.dart
+++ b/lib/features/profile/domain/repositories/sanction_repository.dart
@@ -1,0 +1,30 @@
+import 'package:deelmarkt/features/profile/domain/entities/sanction_entity.dart';
+
+/// Repository interface for account sanctions and appeal flow.
+///
+/// Reference: docs/epics/E06-trust-moderation.md §Account Suspension & Recovery
+/// Reference: docs/SPRINT-PLAN.md R-37
+abstract interface class SanctionRepository {
+  /// Returns the current active suspension or ban for [userId], or null if
+  /// none exists.
+  ///
+  /// Warnings and overturned sanctions are excluded. Delegates to the
+  /// server-side [get_active_sanction] RPC (migration R-37) to avoid
+  /// client-side clock manipulation.
+  Future<SanctionEntity?> getActiveSanction(String userId);
+
+  /// Returns full sanction history for [userId], newest first.
+  Future<List<SanctionEntity>> getAll(String userId);
+
+  /// Submits (or revises) an appeal for [sanctionId] with [appealBody].
+  ///
+  /// Idempotent: a second call updates the body as long as no moderator
+  /// decision has been recorded yet.
+  ///
+  /// Throws if:
+  /// - the sanction belongs to a different user
+  /// - the sanction type is [SanctionType.warning]
+  /// - the 14-day appeal window has closed
+  /// - a final [AppealDecision] has already been issued
+  Future<SanctionEntity> submitAppeal(String sanctionId, String appealBody);
+}

--- a/supabase/functions/send-sanction-notification/deno.json
+++ b/supabase/functions/send-sanction-notification/deno.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "@supabase/functions-js": "jsr:@supabase/functions-js@^2",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@^2",
+    "zod": "https://deno.land/x/zod@v3.22.4/mod.ts"
+  }
+}

--- a/supabase/functions/send-sanction-notification/index.ts
+++ b/supabase/functions/send-sanction-notification/index.ts
@@ -1,0 +1,335 @@
+/**
+ * Send Sanction Notification Edge Function (R-37)
+ *
+ * verify_jwt = false — triggered by database webhook (pg_net) on
+ * account_sanctions INSERT. Auth via service_role check.
+ *
+ * Flow:
+ *   1. Validate payload (Zod).
+ *   2. Idempotency check (Redis NX, keyed by sanction_id) — prevents duplicate
+ *      pushes on pg_net retry.
+ *   3. Fetch user's FCM device tokens from device_tokens.
+ *   4. Build push title/body per sanction type (warning / suspension / ban).
+ *      Note: notification_preferences are NOT checked — sanctions are mandatory
+ *      legal communications, not opt-out push notifications.
+ *   5. Send push via FCM HTTP v1 API using Google service account from Vault.
+ *   6. Clean up stale tokens (FCM UNREGISTERED).
+ *
+ * Reference: docs/epics/E06-trust-moderation.md §Account Suspension & Recovery
+ * Reference: docs/SPRINT-PLAN.md R-37
+ */
+
+import "@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "jsr:@supabase/supabase-js@2";
+import { z } from "https://deno.land/x/zod@v3.22.4/mod.ts";
+import { verifyServiceRole } from "../_shared/auth.ts";
+import { jsonResponse } from "../_shared/response.ts";
+import { getVaultSecret } from "../_shared/vault.ts";
+import { checkIdempotency } from "../_shared/idempotency.ts";
+import { getRedisCredentials } from "../_shared/redis.ts";
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+const SanctionPayloadSchema = z.object({
+  event: z.literal("account_sanctioned"),
+  sanction_id: z.string().uuid(),
+  user_id: z.string().uuid(),
+  type: z.enum(["warning", "suspension", "ban"]),
+  reason: z.string().min(1),
+  expires_at: z.string().nullable().optional(),
+});
+
+type SanctionPayload = z.infer<typeof SanctionPayloadSchema>;
+
+// ---------------------------------------------------------------------------
+// FCM helpers (shared with send-push-notification)
+// ---------------------------------------------------------------------------
+
+interface FcmTokenRow {
+  id: string;
+  token: string;
+  platform: string;
+}
+
+interface ServiceAccount {
+  project_id: string;
+  client_email: string;
+  private_key: string;
+}
+
+interface FcmResult {
+  token: string;
+  success: boolean;
+  unregistered: boolean;
+}
+
+async function getFcmAccessToken(sa: ServiceAccount): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+
+  const header = btoa(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const claims = btoa(
+    JSON.stringify({
+      iss: sa.client_email,
+      scope: "https://www.googleapis.com/auth/firebase.messaging",
+      aud: "https://oauth2.googleapis.com/token",
+      iat: now,
+      exp: now + 3600,
+    }),
+  );
+
+  const signingInput = `${header}.${claims}`;
+  const key = await crypto.subtle.importKey(
+    "pkcs8",
+    pemToArrayBuffer(sa.private_key),
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "RSASSA-PKCS1-v1_5",
+    key,
+    new TextEncoder().encode(signingInput),
+  );
+  const jwt = `${signingInput}.${arrayBufferToBase64Url(signature)}`;
+
+  const res = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body:
+      `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=${jwt}`,
+  });
+
+  if (!res.ok) {
+    throw new Error(`Google OAuth2 failed: ${res.status} ${await res.text()}`);
+  }
+  const data = await res.json();
+  return data.access_token;
+}
+
+function pemToArrayBuffer(pem: string): ArrayBuffer { // pragma: allowlist secret
+  const b64 = pem
+    .replace(/-----BEGIN PRIVATE KEY-----/, "") // pragma: allowlist secret
+    .replace(/-----END PRIVATE KEY-----/, "") // pragma: allowlist secret
+    .replace(/\n/g, "");
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes.buffer;
+}
+
+function arrayBufferToBase64Url(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let str = "";
+  for (const b of bytes) str += String.fromCharCode(b);
+  return btoa(str).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+async function sendFcmMessages(
+  accessToken: string,
+  projectId: string,
+  tokens: FcmTokenRow[],
+  title: string,
+  body: string,
+  data: Record<string, string>,
+): Promise<FcmResult[]> {
+  const url =
+    `https://fcm.googleapis.com/v1/projects/${projectId}/messages:send`;
+
+  return await Promise.all(
+    tokens.map(async (t): Promise<FcmResult> => {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          message: {
+            token: t.token,
+            notification: { title, body },
+            data,
+            android: { priority: "high" },
+            apns: {
+              payload: { aps: { sound: "default", badge: 1 } },
+            },
+          },
+        }),
+      });
+
+      const responseBody = await res.text();
+      const unregistered = !res.ok && responseBody.includes("UNREGISTERED");
+
+      if (!res.ok && !unregistered) {
+        console.error(
+          `[sanction-push] FCM send failed for token ${
+            t.token.slice(0, 8)
+          }...: ${res.status} ${responseBody}`,
+        );
+      }
+
+      return { token: t.token, success: res.ok, unregistered };
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Notification copy per sanction type
+// ---------------------------------------------------------------------------
+
+function buildPushContent(payload: SanctionPayload): {
+  title: string;
+  body: string;
+} {
+  switch (payload.type) {
+    case "warning":
+      return {
+        title: "Account warning",
+        body: `Your account has received a warning: ${payload.reason}`,
+      };
+    case "suspension": {
+      const until = payload.expires_at
+        ? ` until ${new Date(payload.expires_at).toLocaleDateString("nl-NL")}`
+        : "";
+      return {
+        title: "Account suspended",
+        body:
+          `Your account has been suspended${until}. Reason: ${payload.reason}`,
+      };
+    }
+    case "ban":
+      return {
+        title: "Account banned",
+        body:
+          `Your account has been permanently banned. Reason: ${payload.reason}`,
+      };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main handler
+// ---------------------------------------------------------------------------
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Method not allowed" }, 405);
+  }
+
+  if (!verifyServiceRole(req)) {
+    return jsonResponse({ error: "Unauthorized" }, 401);
+  }
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+  );
+
+  let rawBody: unknown;
+  try {
+    rawBody = await req.json();
+  } catch {
+    return jsonResponse({ error: "Invalid JSON body" }, 400);
+  }
+
+  const parsed = SanctionPayloadSchema.safeParse(rawBody);
+  if (!parsed.success) {
+    return jsonResponse({ error: parsed.error.flatten() }, 400);
+  }
+
+  const payload = parsed.data;
+
+  try {
+    // 1. Idempotency — prevent duplicate pushes on pg_net retry.
+    const redis = getRedisCredentials();
+    const isNew = await checkIdempotency(
+      redis,
+      `push:sanction:${payload.sanction_id}`,
+      300,
+    );
+    if (!isNew) {
+      return jsonResponse({ status: "skipped", reason: "duplicate" });
+    }
+
+    // 2. Fetch device tokens (no prefs check — sanctions are mandatory comms).
+    const { data: tokens, error: tokenError } = await supabase
+      .from("device_tokens")
+      .select("id, token, platform")
+      .eq("user_id", payload.user_id);
+
+    if (tokenError) {
+      console.error(
+        `[sanction-push] token lookup failed: ${tokenError.message}`,
+      );
+      return jsonResponse(
+        { status: "error", message: tokenError.message },
+        500,
+      );
+    }
+
+    if (!tokens || tokens.length === 0) {
+      return jsonResponse({ status: "skipped", reason: "no_device_tokens" });
+    }
+
+    // 3. Get FCM credentials from Vault.
+    const sa: ServiceAccount = JSON.parse(
+      await getVaultSecret(supabase, "fcm_service_account"),
+    );
+    const accessToken = await getFcmAccessToken(sa);
+
+    // 4. Build notification content.
+    const { title, body } = buildPushContent(payload);
+
+    // 5. Send FCM messages (parallel for multi-device).
+    const results = await sendFcmMessages(
+      accessToken,
+      sa.project_id,
+      tokens as FcmTokenRow[],
+      title,
+      body,
+      {
+        event: payload.event,
+        sanction_id: payload.sanction_id,
+        type: payload.type,
+      },
+    );
+
+    // 6. Clean up stale tokens.
+    const staleTokenIds = results
+      .filter((r) => r.unregistered)
+      .map((r) => {
+        const match = (tokens as FcmTokenRow[]).find((t) =>
+          t.token === r.token
+        );
+        return match?.id;
+      })
+      .filter(Boolean) as string[];
+
+    if (staleTokenIds.length > 0) {
+      await supabase.from("device_tokens").delete().in("id", staleTokenIds);
+      console.log(
+        `[sanction-push] cleaned ${staleTokenIds.length} stale token(s)`,
+      );
+    }
+
+    const sent = results.filter((r) => r.success).length;
+    const failed = results.filter((r) => !r.success && !r.unregistered).length;
+
+    console.log(
+      `[sanction-push] user=${
+        payload.user_id.slice(0, 8)
+      } type=${payload.type} sent=${sent} failed=${failed} stale=${staleTokenIds.length}`,
+    );
+
+    return jsonResponse({
+      status: "ok",
+      sent,
+      failed,
+      stale_cleaned: staleTokenIds.length,
+    });
+  } catch (error) {
+    const message = (error as Error).message;
+    console.error(`[sanction-push] error: ${message}`);
+    return jsonResponse({ status: "error", message }, 500);
+  }
+});

--- a/supabase/migrations/20260410100000_r37_account_sanctions.sql
+++ b/supabase/migrations/20260410100000_r37_account_sanctions.sql
@@ -40,8 +40,9 @@ CREATE TABLE account_sanctions (
   -- NULL = permanent; set for temporary suspensions (7/14/30 days)
   expires_at  TIMESTAMPTZ,
 
-  -- Moderator who issued the sanction
-  issued_by   UUID              REFERENCES auth.users(id),
+  -- Moderator who issued the sanction.
+  -- ON DELETE SET NULL: preserves the audit trail if a moderator account is removed.
+  issued_by   UUID              REFERENCES auth.users(id) ON DELETE SET NULL,
 
   created_at  TIMESTAMPTZ       NOT NULL DEFAULT now(),
   updated_at  TIMESTAMPTZ,
@@ -53,7 +54,8 @@ CREATE TABLE account_sanctions (
   -- Resolution fields — updated by moderator via service_role
   appeal_decision appeal_decision_t,
   resolved_at TIMESTAMPTZ,
-  resolved_by UUID              REFERENCES auth.users(id),
+  -- ON DELETE SET NULL: same rationale as issued_by.
+  resolved_by UUID              REFERENCES auth.users(id) ON DELETE SET NULL,
 
   -- Bans are always permanent (no expires_at)
   CONSTRAINT sanctions_ban_no_expiry
@@ -205,16 +207,18 @@ GRANT  EXECUTE ON FUNCTION submit_appeal(UUID, TEXT) TO authenticated;
 -- =============================================================================
 -- 7. Push notification trigger on new sanction
 -- =============================================================================
--- On INSERT, fires an async HTTP call to the send-push-notification Edge Function
--- (R-34 infrastructure). The Edge Function resolves FCM tokens from device_tokens,
--- checks notification_preferences, and sends the push with a plain-language message.
+-- On INSERT, fires an async HTTP call to the send-sanction-notification Edge
+-- Function. That function resolves FCM tokens, builds a sanction-specific push
+-- title/body, and skips notification_preferences (sanctions are mandatory legal
+-- comms, not opt-out). Idempotency key: sanction_id.
 --
 -- Payload keys:
---   event      → 'account_sanctioned'  (Edge Function selects template by this)
---   user_id    → sanctioned user
---   type       → 'warning' | 'suspension' | 'ban'
---   reason     → plain-language reason text
---   expires_at → ISO timestamp or null
+--   event       → 'account_sanctioned'
+--   sanction_id → NEW.id (used as Redis idempotency key)
+--   user_id     → sanctioned user
+--   type        → 'warning' | 'suspension' | 'ban'
+--   reason      → plain-language reason text
+--   expires_at  → ISO timestamp or null
 
 CREATE OR REPLACE FUNCTION notify_account_sanctioned()
 RETURNS TRIGGER
@@ -226,16 +230,17 @@ DECLARE
   payload JSONB;
 BEGIN
   payload := jsonb_build_object(
-    'event',      'account_sanctioned',
-    'user_id',    NEW.user_id,
-    'type',       NEW.type::TEXT,
-    'reason',     NEW.reason,
-    'expires_at', NEW.expires_at
+    'event',       'account_sanctioned',
+    'sanction_id', NEW.id,
+    'user_id',     NEW.user_id,
+    'type',        NEW.type::TEXT,
+    'reason',      NEW.reason,
+    'expires_at',  NEW.expires_at
   );
 
   PERFORM net.http_post(
     url     := current_setting('app.settings.supabase_url')
-               || '/functions/v1/send-push-notification',
+               || '/functions/v1/send-sanction-notification',
     headers := jsonb_build_object(
       'Authorization', 'Bearer '
                        || current_setting('app.settings.service_role_key'),

--- a/supabase/migrations/20260410100000_r37_account_sanctions.sql
+++ b/supabase/migrations/20260410100000_r37_account_sanctions.sql
@@ -1,0 +1,253 @@
+-- R-37: Account sanctions + appeal/reinstatement flow
+-- Implements warn/suspend/ban lifecycle from E06-trust-moderation.md §Account Suspension.
+--
+-- Key design decisions:
+-- 1. Sanctions are service_role-only for INSERT/UPDATE. Users read their own via SELECT RLS.
+-- 2. Appeal flow: user calls submit_appeal() RPC (SECURITY INVOKER, RLS enforced).
+--    14-day window, one appeal per sanction, no counter-appeal after decision.
+-- 3. get_active_sanction() RPC: returns latest non-expired suspension/ban.
+--    Warnings never block access — informational only.
+-- 4. Push notification on sanction INSERT: reuses R-34 pg_net + send-push-notification
+--    Edge Function pattern. Edge Function selects FCM template by event type.
+-- 5. Reinstatement: moderator sets appeal_decision = 'overturned' + resolved_at.
+--    Listings are NOT deleted during suspension (RLS blocks new creation only).
+-- 6. Fraudulent seller path: moderator sets type = 'ban'; downstream iDIN revocation
+--    and Wwft flag are handled by admin panel (service_role direct UPDATE).
+--
+-- Reference: docs/epics/E06-trust-moderation.md §Account Suspension & Recovery
+-- Reference: docs/SPRINT-PLAN.md R-37
+
+-- =============================================================================
+-- 1. ENUMs
+-- =============================================================================
+
+CREATE TYPE sanction_type     AS ENUM ('warning', 'suspension', 'ban');
+CREATE TYPE appeal_decision_t AS ENUM ('upheld', 'overturned');
+
+-- =============================================================================
+-- 2. account_sanctions table
+-- =============================================================================
+
+CREATE TABLE account_sanctions (
+  id          UUID              PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID              NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+
+  type        sanction_type     NOT NULL,
+
+  -- Plain-language reason required (E06: no vague "policy violation" allowed)
+  reason      TEXT              NOT NULL CHECK (length(trim(reason)) > 0),
+
+  -- NULL = permanent; set for temporary suspensions (7/14/30 days)
+  expires_at  TIMESTAMPTZ,
+
+  -- Moderator who issued the sanction
+  issued_by   UUID              REFERENCES auth.users(id),
+
+  created_at  TIMESTAMPTZ       NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ,
+
+  -- Appeal fields — populated by submit_appeal() RPC
+  appealed_at TIMESTAMPTZ,
+  appeal_body TEXT,
+
+  -- Resolution fields — updated by moderator via service_role
+  appeal_decision appeal_decision_t,
+  resolved_at TIMESTAMPTZ,
+  resolved_by UUID              REFERENCES auth.users(id),
+
+  -- Bans are always permanent (no expires_at)
+  CONSTRAINT sanctions_ban_no_expiry
+    CHECK (type != 'ban' OR expires_at IS NULL),
+  -- appeal_body required once appeal is submitted
+  CONSTRAINT sanctions_appeal_body_required
+    CHECK (appealed_at IS NULL OR (appeal_body IS NOT NULL AND length(trim(appeal_body)) > 0)),
+  -- resolution requires a prior appeal
+  CONSTRAINT sanctions_resolve_requires_appeal
+    CHECK (resolved_at IS NULL OR appealed_at IS NOT NULL)
+);
+
+CREATE INDEX idx_account_sanctions_user    ON account_sanctions (user_id, created_at DESC);
+CREATE INDEX idx_account_sanctions_active  ON account_sanctions (user_id, expires_at)
+  WHERE type IN ('suspension', 'ban') AND resolved_at IS NULL;
+
+-- =============================================================================
+-- 3. updated_at trigger
+-- =============================================================================
+-- Tracks when a moderator updates the row (appeal decision, reinstatement).
+-- Reuses update_updated_at() defined in 20260321232641.
+
+CREATE TRIGGER account_sanctions_updated_at
+  BEFORE UPDATE ON account_sanctions
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- =============================================================================
+-- 4. RLS — account_sanctions
+-- =============================================================================
+
+ALTER TABLE account_sanctions ENABLE ROW LEVEL SECURITY;
+
+-- Users can read their own sanctions (to show suspension screen + appeal form).
+CREATE POLICY sanctions_own_select ON account_sanctions
+  FOR SELECT USING (user_id = auth.uid());
+
+-- All mutations (INSERT/UPDATE/DELETE) are service_role-only.
+-- Moderator actions go via admin panel (service_role key).
+-- User appeals go via submit_appeal() RPC (SECURITY INVOKER — UPDATE allowed by RPC).
+
+-- =============================================================================
+-- 5. RPC: get_active_sanction
+-- =============================================================================
+-- Returns the most recent active suspension or ban for a user, or empty set.
+-- Warnings are excluded — they are informational only and never block access.
+--
+-- A sanction is "active" when ALL of:
+--   - type IN ('suspension', 'ban')
+--   - appeal_decision IS DISTINCT FROM 'overturned' (not lifted by appeal)
+--   - expires_at IS NULL OR expires_at > now()           (not expired)
+--
+-- Called by the Flutter app on startup / auth state change to gate users.
+
+CREATE OR REPLACE FUNCTION get_active_sanction(p_user_id UUID)
+RETURNS SETOF account_sanctions
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM   public.account_sanctions
+  WHERE  user_id = p_user_id
+    AND  type IN ('suspension', 'ban')
+    AND  (appeal_decision IS DISTINCT FROM 'overturned')
+    AND  (expires_at IS NULL OR expires_at > now())
+  ORDER  BY created_at DESC
+  LIMIT  1;
+$$;
+
+REVOKE ALL ON FUNCTION get_active_sanction(UUID) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION get_active_sanction(UUID) TO authenticated, anon;
+
+-- =============================================================================
+-- 6. RPC: submit_appeal
+-- =============================================================================
+-- Allows a suspended/banned user to submit an appeal within 14 days.
+-- Idempotent: a second call revises the appeal_body (user can edit before decision).
+--
+-- Enforced constraints:
+--   - Caller must be the sanctioned user (SECURITY INVOKER + WHERE user_id = uid).
+--   - Only suspension/ban can be appealed (warnings cannot).
+--   - 14-day appeal window from created_at.
+--   - Cannot appeal after a final decision (no counter-appeal).
+--
+-- Returns the updated sanction row.
+
+CREATE OR REPLACE FUNCTION submit_appeal(
+  p_sanction_id UUID,
+  p_appeal_body TEXT
+)
+RETURNS SETOF account_sanctions
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_sanction public.account_sanctions;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'User must be authenticated to submit an appeal';
+  END IF;
+
+  -- Validate body
+  IF p_appeal_body IS NULL OR length(trim(p_appeal_body)) = 0 THEN
+    RAISE EXCEPTION 'Appeal body must not be empty';
+  END IF;
+
+  -- Fetch and verify ownership
+  SELECT * INTO v_sanction
+  FROM   public.account_sanctions
+  WHERE  id = p_sanction_id
+    AND  user_id = v_user_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Sanction not found or access denied';
+  END IF;
+
+  -- Warnings cannot be appealed
+  IF v_sanction.type = 'warning' THEN
+    RAISE EXCEPTION 'Warnings cannot be appealed';
+  END IF;
+
+  -- Enforce 14-day window
+  IF v_sanction.created_at < now() - INTERVAL '14 days' THEN
+    RAISE EXCEPTION 'Appeal window has closed (14 days from sanction date)';
+  END IF;
+
+  -- No counter-appeal after final decision
+  IF v_sanction.appeal_decision IS NOT NULL THEN
+    RAISE EXCEPTION 'A final decision has already been made — counter-appeal not permitted';
+  END IF;
+
+  -- Upsert: set body; stamp appealed_at only on first submission
+  UPDATE public.account_sanctions
+  SET    appeal_body = p_appeal_body,
+         appealed_at = COALESCE(appealed_at, now())
+  WHERE  id = p_sanction_id;
+
+  RETURN QUERY
+    SELECT * FROM public.account_sanctions WHERE id = p_sanction_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION submit_appeal(UUID, TEXT) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION submit_appeal(UUID, TEXT) TO authenticated;
+
+-- =============================================================================
+-- 7. Push notification trigger on new sanction
+-- =============================================================================
+-- On INSERT, fires an async HTTP call to the send-push-notification Edge Function
+-- (R-34 infrastructure). The Edge Function resolves FCM tokens from device_tokens,
+-- checks notification_preferences, and sends the push with a plain-language message.
+--
+-- Payload keys:
+--   event      → 'account_sanctioned'  (Edge Function selects template by this)
+--   user_id    → sanctioned user
+--   type       → 'warning' | 'suspension' | 'ban'
+--   reason     → plain-language reason text
+--   expires_at → ISO timestamp or null
+
+CREATE OR REPLACE FUNCTION notify_account_sanctioned()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  payload JSONB;
+BEGIN
+  payload := jsonb_build_object(
+    'event',      'account_sanctioned',
+    'user_id',    NEW.user_id,
+    'type',       NEW.type::TEXT,
+    'reason',     NEW.reason,
+    'expires_at', NEW.expires_at
+  );
+
+  PERFORM net.http_post(
+    url     := current_setting('app.settings.supabase_url')
+               || '/functions/v1/send-push-notification',
+    headers := jsonb_build_object(
+      'Authorization', 'Bearer '
+                       || current_setting('app.settings.service_role_key'),
+      'Content-Type',  'application/json'
+    ),
+    body    := payload
+  );
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER account_sanctions_push_notify
+  AFTER INSERT ON public.account_sanctions
+  FOR EACH ROW EXECUTE FUNCTION notify_account_sanctioned();

--- a/test/features/profile/data/dto/sanction_dto_test.dart
+++ b/test/features/profile/data/dto/sanction_dto_test.dart
@@ -1,0 +1,169 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:deelmarkt/features/profile/data/dto/sanction_dto.dart';
+import 'package:deelmarkt/features/profile/domain/entities/sanction_entity.dart';
+
+Map<String, dynamic> _validJson({
+  String id = 'sanction-001',
+  String userId = 'user-001',
+  String type = 'suspension',
+  String reason = 'Fraudulent activity',
+  String createdAt = '2026-04-01T10:00:00Z',
+  String? expiresAt = '2026-04-08T10:00:00Z',
+  String? appealedAt,
+  String? appealBody,
+  String? appealDecision,
+  String? resolvedAt,
+}) => {
+  'id': id,
+  'user_id': userId,
+  'type': type,
+  'reason': reason,
+  'created_at': createdAt,
+  if (expiresAt != null) 'expires_at': expiresAt,
+  if (appealedAt != null) 'appealed_at': appealedAt,
+  if (appealBody != null) 'appeal_body': appealBody,
+  if (appealDecision != null) 'appeal_decision': appealDecision,
+  if (resolvedAt != null) 'resolved_at': resolvedAt,
+};
+
+void main() {
+  group('SanctionDto.fromJson', () {
+    test('parses valid suspension JSON', () {
+      final result = SanctionDto.fromJson(_validJson());
+
+      expect(result, isA<SanctionEntity>());
+      expect(result.id, 'sanction-001');
+      expect(result.userId, 'user-001');
+      expect(result.type, SanctionType.suspension);
+      expect(result.reason, 'Fraudulent activity');
+      expect(result.expiresAt, isNotNull);
+    });
+
+    test('parses warning type', () {
+      final result = SanctionDto.fromJson(
+        _validJson(type: 'warning', expiresAt: null),
+      );
+      expect(result.type, SanctionType.warning);
+      expect(result.expiresAt, isNull);
+    });
+
+    test('parses ban type', () {
+      final result = SanctionDto.fromJson(
+        _validJson(type: 'ban', expiresAt: null),
+      );
+      expect(result.type, SanctionType.ban);
+    });
+
+    test('parses appeal fields', () {
+      final result = SanctionDto.fromJson(
+        _validJson(
+          appealedAt: '2026-04-02T10:00:00Z',
+          appealBody: 'I did nothing wrong',
+        ),
+      );
+
+      expect(result.appealedAt, isNotNull);
+      expect(result.appealBody, 'I did nothing wrong');
+      expect(result.appealDecision, isNull);
+    });
+
+    test('parses upheld appeal decision', () {
+      final result = SanctionDto.fromJson(
+        _validJson(
+          appealedAt: '2026-04-02T10:00:00Z',
+          appealBody: 'I appeal',
+          appealDecision: 'upheld',
+          resolvedAt: '2026-04-04T10:00:00Z',
+        ),
+      );
+
+      expect(result.appealDecision, AppealDecision.upheld);
+      expect(result.resolvedAt, isNotNull);
+    });
+
+    test('parses overturned appeal decision', () {
+      final result = SanctionDto.fromJson(
+        _validJson(
+          appealedAt: '2026-04-02T10:00:00Z',
+          appealBody: 'I appeal',
+          appealDecision: 'overturned',
+          resolvedAt: '2026-04-04T10:00:00Z',
+        ),
+      );
+
+      expect(result.appealDecision, AppealDecision.overturned);
+    });
+
+    test('throws FormatException for missing id', () {
+      final json = _validJson()..remove('id');
+      expect(() => SanctionDto.fromJson(json), throwsFormatException);
+    });
+
+    test('throws FormatException for missing user_id', () {
+      final json = _validJson()..remove('user_id');
+      expect(() => SanctionDto.fromJson(json), throwsFormatException);
+    });
+
+    test('throws FormatException for missing type', () {
+      final json = _validJson()..remove('type');
+      expect(() => SanctionDto.fromJson(json), throwsFormatException);
+    });
+
+    test('throws FormatException for missing reason', () {
+      final json = _validJson()..remove('reason');
+      expect(() => SanctionDto.fromJson(json), throwsFormatException);
+    });
+
+    test('throws FormatException for unknown type', () {
+      final json = _validJson(type: 'probation');
+      expect(() => SanctionDto.fromJson(json), throwsFormatException);
+    });
+
+    test('throws FormatException for unknown appeal_decision', () {
+      final json = _validJson(
+        appealedAt: '2026-04-02T10:00:00Z',
+        appealBody: 'I appeal',
+        appealDecision: 'pending',
+      );
+      expect(() => SanctionDto.fromJson(json), throwsFormatException);
+    });
+
+    test('null expires_at parses as null', () {
+      final json = _validJson(expiresAt: null);
+      expect(SanctionDto.fromJson(json).expiresAt, isNull);
+    });
+
+    test('invalid created_at falls back to DateTime.now()', () {
+      final json = _validJson(createdAt: 'not-a-date');
+      expect(SanctionDto.fromJson(json).createdAt, isNotNull);
+    });
+  });
+
+  group('SanctionDto.fromJsonList', () {
+    test('parses a valid list', () {
+      final list = [
+        _validJson(),
+        _validJson(id: 'sanction-002', type: 'warning', expiresAt: null),
+      ];
+      expect(SanctionDto.fromJsonList(list).length, 2);
+    });
+
+    test('skips malformed entries', () {
+      final list = [
+        _validJson(),
+        <String, dynamic>{'id': 'bad'},
+      ];
+      expect(SanctionDto.fromJsonList(list).length, 1);
+    });
+
+    test('skips non-map entries', () {
+      final list = ['not-a-map', 42, _validJson()];
+      expect(SanctionDto.fromJsonList(list).length, 1);
+    });
+
+    test('returns empty list for empty input', () {
+      expect(SanctionDto.fromJsonList([]), isEmpty);
+    });
+  });
+}

--- a/test/features/profile/data/dto/sanction_dto_test.dart
+++ b/test/features/profile/data/dto/sanction_dto_test.dart
@@ -134,9 +134,9 @@ void main() {
       expect(SanctionDto.fromJson(json).expiresAt, isNull);
     });
 
-    test('invalid created_at falls back to DateTime.now()', () {
+    test('invalid created_at throws FormatException', () {
       final json = _validJson(createdAt: 'not-a-date');
-      expect(SanctionDto.fromJson(json).createdAt, isNotNull);
+      expect(() => SanctionDto.fromJson(json), throwsFormatException);
     });
   });
 

--- a/test/features/profile/data/mock/mock_sanction_repository_test.dart
+++ b/test/features/profile/data/mock/mock_sanction_repository_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:deelmarkt/features/profile/data/mock/mock_sanction_repository.dart';
+import 'package:deelmarkt/features/profile/domain/entities/sanction_entity.dart';
+
+void main() {
+  group('MockSanctionRepository (default — no active sanction)', () {
+    late MockSanctionRepository repository;
+
+    setUp(() {
+      repository = MockSanctionRepository();
+    });
+
+    test('getActiveSanction returns null by default', () async {
+      final result = await repository.getActiveSanction('user-001');
+      expect(result, isNull);
+    });
+
+    test('getAll returns empty list', () async {
+      final result = await repository.getAll('user-001');
+      expect(result, isEmpty);
+    });
+
+    test('submitAppeal returns a SanctionEntity with appealedAt set', () async {
+      final result = await repository.submitAppeal(
+        'sanction-001',
+        'I did not violate any rules',
+      );
+
+      expect(result, isA<SanctionEntity>());
+      expect(result.id, 'sanction-001');
+      expect(result.appealedAt, isNotNull);
+      expect(result.appealBody, 'I did not violate any rules');
+    });
+  });
+
+  group('MockSanctionRepository (with activeForUserId)', () {
+    late MockSanctionRepository repository;
+
+    setUp(() {
+      repository = MockSanctionRepository(activeForUserId: 'suspended-user');
+    });
+
+    test(
+      'getActiveSanction returns mock suspension for matching user',
+      () async {
+        final result = await repository.getActiveSanction('suspended-user');
+
+        expect(result, isNotNull);
+        expect(result!.type, SanctionType.suspension);
+        expect(result.isActive, true);
+      },
+    );
+
+    test('getActiveSanction returns null for different user', () async {
+      final result = await repository.getActiveSanction('other-user');
+      expect(result, isNull);
+    });
+
+    test('mock suspension has future expiresAt', () async {
+      final result = await repository.getActiveSanction('suspended-user');
+
+      expect(result!.expiresAt, isNotNull);
+      expect(result.expiresAt!.isAfter(DateTime.now()), true);
+    });
+  });
+}

--- a/test/features/profile/data/supabase/supabase_sanction_repository_test.dart
+++ b/test/features/profile/data/supabase/supabase_sanction_repository_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:deelmarkt/features/profile/data/supabase/supabase_sanction_repository.dart';
+import 'package:deelmarkt/features/profile/domain/entities/sanction_entity.dart';
+
+/// Minimal Supabase client that uses the real URL but no auth.
+/// All RPC calls will throw a [PostgrestException] or [TypeError] —
+/// we only test auth-guard logic and error translation here.
+SupabaseClient _unauthClient() =>
+    SupabaseClient('https://test.supabase.co', 'test-anon-key');
+
+void main() {
+  late SupabaseSanctionRepository repository;
+
+  setUp(() {
+    repository = SupabaseSanctionRepository(_unauthClient());
+  });
+
+  group('submitAppeal', () {
+    test('throws when user is not authenticated', () async {
+      await expectLater(
+        () => repository.submitAppeal('sanction-001', 'I appeal'),
+        throwsA(anything),
+      );
+    });
+  });
+
+  group('getActiveSanction', () {
+    test('throws when Supabase client is unmocked', () async {
+      await expectLater(
+        () => repository.getActiveSanction('user-001'),
+        throwsA(anything),
+      );
+    });
+  });
+
+  group('getAll', () {
+    test('throws when Supabase client is unmocked', () async {
+      await expectLater(() => repository.getAll('user-001'), throwsA(anything));
+    });
+  });
+
+  group('SanctionEntity business logic (no Supabase required)', () {
+    test('active suspension blocks access', () {
+      final sanction = SanctionEntity(
+        id: 's1',
+        userId: 'u1',
+        type: SanctionType.suspension,
+        reason: 'Fraud',
+        createdAt: DateTime.now().subtract(const Duration(days: 1)),
+        expiresAt: DateTime.now().add(const Duration(days: 6)),
+      );
+
+      expect(sanction.isActive, true);
+    });
+
+    test('overturned ban does not block access', () {
+      final sanction = SanctionEntity(
+        id: 's2',
+        userId: 'u1',
+        type: SanctionType.ban,
+        reason: 'Fraud',
+        createdAt: DateTime.now().subtract(const Duration(days: 10)),
+        appealDecision: AppealDecision.overturned,
+      );
+
+      expect(sanction.isActive, false);
+    });
+
+    test('appeal pending when appealed but no decision', () {
+      final sanction = SanctionEntity(
+        id: 's3',
+        userId: 'u1',
+        type: SanctionType.suspension,
+        reason: 'Test',
+        createdAt: DateTime.now().subtract(const Duration(days: 2)),
+        appealedAt: DateTime.now().subtract(const Duration(days: 1)),
+        appealBody: 'I appeal',
+      );
+
+      expect(sanction.isAppealPending, true);
+      expect(sanction.canAppeal, true);
+    });
+
+    test('canAppeal false when 14-day window closed', () {
+      final sanction = SanctionEntity(
+        id: 's4',
+        userId: 'u1',
+        type: SanctionType.suspension,
+        reason: 'Test',
+        createdAt: DateTime.now().subtract(const Duration(days: 15)),
+      );
+
+      expect(sanction.canAppeal, false);
+    });
+
+    test('warning never blocks and cannot be appealed', () {
+      final sanction = SanctionEntity(
+        id: 's5',
+        userId: 'u1',
+        type: SanctionType.warning,
+        reason: 'Minor rule violation',
+        createdAt: DateTime.now(),
+      );
+
+      expect(sanction.isActive, false);
+      expect(sanction.canAppeal, false);
+    });
+  });
+}

--- a/test/features/profile/domain/entities/sanction_entity_test.dart
+++ b/test/features/profile/domain/entities/sanction_entity_test.dart
@@ -1,0 +1,242 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:deelmarkt/features/profile/domain/entities/sanction_entity.dart';
+
+void main() {
+  group('SanctionEntity.isActive', () {
+    test('warning is never active (never blocks access)', () {
+      final warning = SanctionEntity(
+        id: 's1',
+        userId: 'u1',
+        type: SanctionType.warning,
+        reason: 'Test',
+        createdAt: DateTime.now(),
+      );
+
+      expect(warning.isActive, false);
+    });
+
+    test('active suspension with no expiry is active', () {
+      final suspension = SanctionEntity(
+        id: 's2',
+        userId: 'u1',
+        type: SanctionType.suspension,
+        reason: 'Test',
+        createdAt: DateTime.now().subtract(const Duration(days: 1)),
+        expiresAt: DateTime.now().add(const Duration(days: 6)),
+      );
+
+      expect(suspension.isActive, true);
+    });
+
+    test('expired suspension is not active', () {
+      final suspension = SanctionEntity(
+        id: 's3',
+        userId: 'u1',
+        type: SanctionType.suspension,
+        reason: 'Test',
+        createdAt: DateTime.now().subtract(const Duration(days: 10)),
+        expiresAt: DateTime.now().subtract(const Duration(days: 3)),
+      );
+
+      expect(suspension.isActive, false);
+    });
+
+    test('overturned suspension is not active', () {
+      final suspension = SanctionEntity(
+        id: 's4',
+        userId: 'u1',
+        type: SanctionType.suspension,
+        reason: 'Test',
+        createdAt: DateTime.now().subtract(const Duration(days: 2)),
+        expiresAt: DateTime.now().add(const Duration(days: 5)),
+        appealDecision: AppealDecision.overturned,
+      );
+
+      expect(suspension.isActive, false);
+    });
+
+    test('upheld suspension remains active', () {
+      final suspension = SanctionEntity(
+        id: 's5',
+        userId: 'u1',
+        type: SanctionType.suspension,
+        reason: 'Test',
+        createdAt: DateTime.now().subtract(const Duration(days: 2)),
+        expiresAt: DateTime.now().add(const Duration(days: 5)),
+        appealDecision: AppealDecision.upheld,
+      );
+
+      expect(suspension.isActive, true);
+    });
+
+    test('permanent ban with no expiry is active', () {
+      final ban = SanctionEntity(
+        id: 's6',
+        userId: 'u1',
+        type: SanctionType.ban,
+        reason: 'Test',
+        createdAt: DateTime.now().subtract(const Duration(days: 30)),
+      );
+
+      expect(ban.isActive, true);
+    });
+  });
+
+  group('SanctionEntity.canAppeal', () {
+    test('warning cannot be appealed', () {
+      final warning = SanctionEntity(
+        id: 's1',
+        userId: 'u1',
+        type: SanctionType.warning,
+        reason: 'Test',
+        createdAt: DateTime.now(),
+      );
+
+      expect(warning.canAppeal, false);
+    });
+
+    test('recent suspension without decision can be appealed', () {
+      final suspension = SanctionEntity(
+        id: 's2',
+        userId: 'u1',
+        type: SanctionType.suspension,
+        reason: 'Test',
+        createdAt: DateTime.now().subtract(const Duration(days: 1)),
+      );
+
+      expect(suspension.canAppeal, true);
+    });
+
+    test('suspension older than 14 days cannot be appealed', () {
+      final suspension = SanctionEntity(
+        id: 's3',
+        userId: 'u1',
+        type: SanctionType.suspension,
+        reason: 'Test',
+        createdAt: DateTime.now().subtract(const Duration(days: 15)),
+      );
+
+      expect(suspension.canAppeal, false);
+    });
+
+    test('suspension with existing decision cannot be appealed', () {
+      final suspension = SanctionEntity(
+        id: 's4',
+        userId: 'u1',
+        type: SanctionType.suspension,
+        reason: 'Test',
+        createdAt: DateTime.now().subtract(const Duration(days: 1)),
+        appealDecision: AppealDecision.upheld,
+      );
+
+      expect(suspension.canAppeal, false);
+    });
+  });
+
+  group('SanctionEntity.isAppealPending', () {
+    test('returns true when appealed but no decision', () {
+      final sanction = SanctionEntity(
+        id: 's1',
+        userId: 'u1',
+        type: SanctionType.suspension,
+        reason: 'Test',
+        createdAt: DateTime.now().subtract(const Duration(days: 1)),
+        appealedAt: DateTime.now(),
+        appealBody: 'I appeal this',
+      );
+
+      expect(sanction.isAppealPending, true);
+    });
+
+    test('returns false when not appealed', () {
+      final sanction = SanctionEntity(
+        id: 's2',
+        userId: 'u1',
+        type: SanctionType.suspension,
+        reason: 'Test',
+        createdAt: DateTime.now(),
+      );
+
+      expect(sanction.isAppealPending, false);
+    });
+
+    test('returns false when decision has been made', () {
+      final sanction = SanctionEntity(
+        id: 's3',
+        userId: 'u1',
+        type: SanctionType.suspension,
+        reason: 'Test',
+        createdAt: DateTime.now().subtract(const Duration(days: 3)),
+        appealedAt: DateTime.now().subtract(const Duration(days: 2)),
+        appealBody: 'I appeal this',
+        appealDecision: AppealDecision.upheld,
+      );
+
+      expect(sanction.isAppealPending, false);
+    });
+  });
+
+  group('SanctionEntity equality', () {
+    test('two entities with same id are equal', () {
+      final a = SanctionEntity(
+        id: 'same-id',
+        userId: 'u1',
+        type: SanctionType.suspension,
+        reason: 'Test',
+        createdAt: DateTime.now(),
+      );
+      final b = SanctionEntity(
+        id: 'same-id',
+        userId: 'u2',
+        type: SanctionType.ban,
+        reason: 'Different reason',
+        createdAt: DateTime.now(),
+      );
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('two entities with different ids are not equal', () {
+      final a = SanctionEntity(
+        id: 'id-a',
+        userId: 'u1',
+        type: SanctionType.suspension,
+        reason: 'Test',
+        createdAt: DateTime.now(),
+      );
+      final b = SanctionEntity(
+        id: 'id-b',
+        userId: 'u1',
+        type: SanctionType.suspension,
+        reason: 'Test',
+        createdAt: DateTime.now(),
+      );
+
+      expect(a, isNot(equals(b)));
+    });
+  });
+
+  group('SanctionType enum', () {
+    test('all values exist', () {
+      expect(
+        SanctionType.values,
+        containsAll([
+          SanctionType.warning,
+          SanctionType.suspension,
+          SanctionType.ban,
+        ]),
+      );
+    });
+  });
+
+  group('AppealDecision enum', () {
+    test('all values exist', () {
+      expect(
+        AppealDecision.values,
+        containsAll([AppealDecision.upheld, AppealDecision.overturned]),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- **Migration** (`20260410100000_r37_account_sanctions.sql`): `account_sanctions` table with `warning | suspension | ban` types, appeal fields, resolution fields, RLS, `get_active_sanction()` + `submit_appeal()` RPCs, and push notification trigger on INSERT (reuses R-34 FCM infrastructure)
- **Domain**: `SanctionEntity` with computed `isActive` / `canAppeal` / `isAppealPending`; `SanctionRepository` interface
- **Data layer**: `SanctionDto`, `MockSanctionRepository` (with `activeForUserId` override for UI testing), `SupabaseSanctionRepository`
- **Provider**: `sanctionRepositoryProvider` wired with `useMockDataProvider` gate
- **L10n**: `sanction.*` keys added to `en-US.json` + `nl-NL.json` (type labels, screen copy, appeal flow states, a11y)
- **49 new tests**: entity business logic, DTO parsing (happy + error paths), mock repo, Supabase repo auth-guard

## Key design decisions

| Decision | Rationale |
|:---------|:----------|
| `get_active_sanction` as RPC | Avoids client-side clock manipulation; server evaluates `expires_at > now()` |
| Warnings never block access | Informational only — user can still transact; keeps UX frictionless for minor violations |
| `submit_appeal` idempotent | User can revise appeal body before moderator decision; `appealed_at` stamped on first call only |
| No `updated_at` separate audit | Moderator writes directly via `service_role`; `updated_at` trigger covers admin panel edits |
| Push trigger reuses R-34 | `send-push-notification` Edge Function selects template by `event = 'account_sanctioned'` |

## Test plan

- [x] `flutter analyze` — zero warnings
- [x] `flutter test` — 2495 tests passing
- [x] Coverage gate — 87.1% on changed files (threshold 80%)
- [ ] Apply migration: `bash scripts/check_deployments.sh --deploy`
- [ ] Manual: issue a test sanction via service_role, verify push received + `get_active_sanction` returns it
- [ ] Manual: `submit_appeal` within + outside 14-day window
- [ ] Manual: moderator sets `appeal_decision = 'overturned'`, verify `isActive` → false

🤖 Generated with [Claude Code](https://claude.com/claude-code)