### PR TITLE
feat(trust): R-38 — DSA notice-and-action reporting table + 24h SLA

### DIFF
--- a/assets/l10n/en-US.json
+++ b/assets/l10n/en-US.json
@@ -789,5 +789,42 @@
       "sanction_icon": "Account suspended icon",
       "appeal_form": "Appeal form"
     }
+  },
+  "dsa_report": {
+    "title": "Report content",
+    "subtitle": "Report illegal or prohibited content to our moderation team.",
+    "target_type": {
+      "listing": "Listing",
+      "message": "Message",
+      "profile": "Profile",
+      "review": "Review"
+    },
+    "category": {
+      "label": "Reason",
+      "illegal_content": "Illegal content",
+      "prohibited_item": "Prohibited item",
+      "counterfeit": "Counterfeit goods",
+      "fraud": "Fraud or scam",
+      "privacy_violation": "Privacy violation",
+      "other": "Other"
+    },
+    "description_label": "Description",
+    "description_hint": "Describe the issue in detail (minimum 10 characters)",
+    "submit": "Submit report",
+    "submit_success": "Your report has been submitted. We will review it within 24 hours.",
+    "submit_error": "Could not submit your report. Please try again.",
+    "status": {
+      "pending": "Pending review",
+      "under_review": "Under review",
+      "actioned": "Action taken",
+      "rejected": "Report rejected"
+    },
+    "sla_breached": "Review overdue",
+    "history_title": "My reports",
+    "history_empty": "You have not submitted any reports.",
+    "a11y": {
+      "report_icon": "Report content icon",
+      "submit_button": "Submit DSA report"
+    }
   }
 }

--- a/assets/l10n/nl-NL.json
+++ b/assets/l10n/nl-NL.json
@@ -789,5 +789,42 @@
       "sanction_icon": "Pictogram account geschorst",
       "appeal_form": "Bezwaarformulier"
     }
+  },
+  "dsa_report": {
+    "title": "Inhoud melden",
+    "subtitle": "Meld illegale of verboden inhoud aan ons moderatieteam.",
+    "target_type": {
+      "listing": "Advertentie",
+      "message": "Bericht",
+      "profile": "Profiel",
+      "review": "Recensie"
+    },
+    "category": {
+      "label": "Reden",
+      "illegal_content": "Illegale inhoud",
+      "prohibited_item": "Verboden artikel",
+      "counterfeit": "Namaakgoederen",
+      "fraud": "Fraude of oplichting",
+      "privacy_violation": "Privacyschending",
+      "other": "Overig"
+    },
+    "description_label": "Beschrijving",
+    "description_hint": "Beschrijf het probleem in detail (minimaal 10 tekens)",
+    "submit": "Melding indienen",
+    "submit_success": "Uw melding is ingediend. We bekijken deze binnen 24 uur.",
+    "submit_error": "Melding kon niet worden ingediend. Probeer het opnieuw.",
+    "status": {
+      "pending": "In afwachting van beoordeling",
+      "under_review": "In behandeling",
+      "actioned": "Actie ondernomen",
+      "rejected": "Melding afgewezen"
+    },
+    "sla_breached": "Beoordeling te laat",
+    "history_title": "Mijn meldingen",
+    "history_empty": "U heeft nog geen meldingen ingediend.",
+    "a11y": {
+      "report_icon": "Pictogram inhoud melden",
+      "submit_button": "DSA-melding indienen"
+    }
   }
 }

--- a/docs/SPRINT-PLAN.md
+++ b/docs/SPRINT-PLAN.md
@@ -247,9 +247,9 @@ The agent will:
 - [x] `R-34` FCM push notification on new message — delivered on iOS + Android *(PR #94)*
 - [x] `R-35` E06 scam detection Edge Function — flagged/clean in <1s
 - [x] `R-36` Reviews table + blind review logic — hidden until both submit *(PR #98)*
-- [ ] `R-37` Account suspension/appeal tables + flow — suspend/appeal/reinstate *(branch: `feature/reso-E06-r37-suspension`)* **[backend-only — UI tracked as P-53]**
+- [x] `R-37` Account suspension/appeal tables + flow — suspend/appeal/reinstate *(PR #102)* **[backend-only — UI tracked as P-53]**
   > **Email follow-up:** Sanction email notifications are not included in R-37. Email delivery via Supabase SMTP / Resend will be tracked as a separate task once the email provider is configured.
-- [ ] `R-38` DSA notice-and-action reporting table — 24hr SLA tracked
+- [ ] `R-38` DSA notice-and-action reporting table — 24hr SLA tracked *(branch: `feature/reso-E06-r38-dsa-reports`)*
 
 ### belengaz `[B]` — Message Data Layer + Monitoring + Security
 

--- a/lib/core/services/repository_providers.dart
+++ b/lib/core/services/repository_providers.dart
@@ -9,14 +9,17 @@ import 'package:deelmarkt/features/home/domain/repositories/listing_repository.d
 import 'package:deelmarkt/features/messages/data/mock/mock_message_repository.dart';
 import 'package:deelmarkt/features/messages/data/supabase/supabase_message_repository.dart';
 import 'package:deelmarkt/features/messages/domain/repositories/message_repository.dart';
+import 'package:deelmarkt/features/profile/data/mock/mock_dsa_report_repository.dart';
 import 'package:deelmarkt/features/profile/data/mock/mock_review_repository.dart';
 import 'package:deelmarkt/features/profile/data/mock/mock_sanction_repository.dart';
 import 'package:deelmarkt/features/profile/data/mock/mock_settings_repository.dart';
+import 'package:deelmarkt/features/profile/data/supabase/supabase_dsa_report_repository.dart';
 import 'package:deelmarkt/features/profile/data/supabase/supabase_review_repository.dart';
 import 'package:deelmarkt/features/profile/data/supabase/supabase_sanction_repository.dart';
 import 'package:deelmarkt/features/profile/data/supabase/supabase_settings_repository.dart';
 import 'package:deelmarkt/features/profile/data/mock/mock_user_repository.dart';
 import 'package:deelmarkt/features/profile/data/supabase/supabase_user_repository.dart';
+import 'package:deelmarkt/features/profile/domain/repositories/dsa_report_repository.dart';
 import 'package:deelmarkt/features/profile/domain/repositories/review_repository.dart';
 import 'package:deelmarkt/features/profile/domain/repositories/sanction_repository.dart';
 import 'package:deelmarkt/features/profile/domain/repositories/settings_repository.dart';
@@ -115,4 +118,11 @@ final sanctionRepositoryProvider = Provider<SanctionRepository>((ref) {
   final useMock = ref.watch(useMockDataProvider);
   if (useMock) return MockSanctionRepository();
   return SupabaseSanctionRepository(ref.watch(supabaseClientProvider));
+});
+
+/// DSA report repository — mock or Supabase based on [useMockDataProvider].
+final dsaReportRepositoryProvider = Provider<DsaReportRepository>((ref) {
+  final useMock = ref.watch(useMockDataProvider);
+  if (useMock) return MockDsaReportRepository();
+  return SupabaseDsaReportRepository(ref.watch(supabaseClientProvider));
 });

--- a/lib/features/profile/data/dto/dsa_report_dto.dart
+++ b/lib/features/profile/data/dto/dsa_report_dto.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/foundation.dart';
+
+import 'package:deelmarkt/features/profile/domain/entities/dsa_report_entity.dart';
+
+/// Maps raw Supabase JSON rows from [dsa_reports] to [DsaReportEntity].
+///
+/// Reference: docs/SPRINT-PLAN.md R-38
+class DsaReportDto {
+  DsaReportDto._();
+
+  static DsaReportEntity fromJson(Map<String, dynamic> json) {
+    final id = json['id'] as String?;
+    final targetTypeRaw = json['target_type'] as String?;
+    final targetId = json['target_id'] as String?;
+    final categoryRaw = json['category'] as String?;
+    final description = json['description'] as String?;
+    final reportedAtRaw = json['reported_at'] as String?;
+    final slaDeadlineRaw = json['sla_deadline'] as String?;
+    final statusRaw = json['status'] as String?;
+
+    if (id == null ||
+        id.isEmpty ||
+        targetTypeRaw == null ||
+        targetId == null ||
+        targetId.isEmpty ||
+        categoryRaw == null ||
+        description == null ||
+        description.isEmpty ||
+        reportedAtRaw == null ||
+        slaDeadlineRaw == null ||
+        statusRaw == null) {
+      throw const FormatException(
+        'DsaReportDto.fromJson: missing required fields',
+      );
+    }
+
+    final targetType = _parseTargetType(targetTypeRaw);
+    final category = _parseCategory(categoryRaw);
+    final status = _parseStatus(statusRaw);
+
+    return DsaReportEntity(
+      id: id,
+      reporterId: json['reporter_id'] as String?,
+      targetType: targetType,
+      targetId: targetId,
+      category: category,
+      description: description,
+      reportedAt: DateTime.parse(reportedAtRaw),
+      slaDeadline: DateTime.parse(slaDeadlineRaw),
+      status: status,
+      reviewedBy: json['reviewed_by'] as String?,
+      reviewedAt: _parseDate(json['reviewed_at']),
+      resolutionNotes: json['resolution_notes'] as String?,
+    );
+  }
+
+  static DsaTargetType _parseTargetType(String raw) {
+    return switch (raw) {
+      'listing' => DsaTargetType.listing,
+      'message' => DsaTargetType.message,
+      'profile' => DsaTargetType.profile,
+      'review' => DsaTargetType.review,
+      _ => throw FormatException('DsaReportDto: unknown target_type: $raw'),
+    };
+  }
+
+  static DsaReportCategory _parseCategory(String raw) {
+    return switch (raw) {
+      'illegal_content' => DsaReportCategory.illegalContent,
+      'prohibited_item' => DsaReportCategory.prohibitedItem,
+      'counterfeit' => DsaReportCategory.counterfeit,
+      'fraud' => DsaReportCategory.fraud,
+      'privacy_violation' => DsaReportCategory.privacyViolation,
+      'other' => DsaReportCategory.other,
+      _ => throw FormatException('DsaReportDto: unknown category: $raw'),
+    };
+  }
+
+  static DsaReportStatus _parseStatus(String raw) {
+    return switch (raw) {
+      'pending' => DsaReportStatus.pending,
+      'under_review' => DsaReportStatus.underReview,
+      'actioned' => DsaReportStatus.actioned,
+      'rejected' => DsaReportStatus.rejected,
+      _ => throw FormatException('DsaReportDto: unknown status: $raw'),
+    };
+  }
+
+  static DateTime? _parseDate(dynamic raw) {
+    if (raw is! String) return null;
+    return DateTime.tryParse(raw);
+  }
+
+  /// Parses a list, silently skipping malformed entries.
+  static List<DsaReportEntity> fromJsonList(List<dynamic> list) {
+    final result = <DsaReportEntity>[];
+    for (final item in list) {
+      if (item is! Map<String, dynamic>) continue;
+      try {
+        result.add(fromJson(item));
+      } on FormatException catch (e) {
+        debugPrint('DsaReportDto.fromJsonList: skipping malformed row — $e');
+        continue;
+      }
+    }
+    return result;
+  }
+
+  static String targetTypeToDb(DsaTargetType type) {
+    return switch (type) {
+      DsaTargetType.listing => 'listing',
+      DsaTargetType.message => 'message',
+      DsaTargetType.profile => 'profile',
+      DsaTargetType.review => 'review',
+    };
+  }
+
+  static String categoryToDb(DsaReportCategory category) {
+    return switch (category) {
+      DsaReportCategory.illegalContent => 'illegal_content',
+      DsaReportCategory.prohibitedItem => 'prohibited_item',
+      DsaReportCategory.counterfeit => 'counterfeit',
+      DsaReportCategory.fraud => 'fraud',
+      DsaReportCategory.privacyViolation => 'privacy_violation',
+      DsaReportCategory.other => 'other',
+    };
+  }
+}

--- a/lib/features/profile/data/mock/mock_dsa_report_repository.dart
+++ b/lib/features/profile/data/mock/mock_dsa_report_repository.dart
@@ -1,0 +1,48 @@
+import 'package:deelmarkt/features/profile/domain/entities/dsa_report_entity.dart';
+import 'package:deelmarkt/features/profile/domain/repositories/dsa_report_repository.dart';
+
+/// Mock implementation of [DsaReportRepository] for development + widget tests.
+///
+/// Default: [getMyReports] returns an empty list (clean state).
+/// Provide [preloadedReports] to seed the repository with existing reports.
+///
+/// Reference: docs/SPRINT-PLAN.md R-38
+class MockDsaReportRepository implements DsaReportRepository {
+  MockDsaReportRepository({List<DsaReportEntity>? preloadedReports})
+    : _reports = preloadedReports?.toList() ?? [];
+
+  final List<DsaReportEntity> _reports;
+
+  @override
+  Future<DsaReportEntity> submit({
+    required DsaTargetType targetType,
+    required String targetId,
+    required DsaReportCategory category,
+    required String description,
+  }) async {
+    // Idempotent: return existing if same (target_type, target_id) exists.
+    final existing = _reports.where(
+      (r) => r.targetType == targetType && r.targetId == targetId,
+    );
+    if (existing.isNotEmpty) return existing.first;
+
+    final now = DateTime.now();
+    final report = DsaReportEntity(
+      id: 'mock-dsa-${_reports.length + 1}',
+      reporterId: 'mock-user-001',
+      targetType: targetType,
+      targetId: targetId,
+      category: category,
+      description: description,
+      reportedAt: now,
+      slaDeadline: now.add(const Duration(hours: 24)),
+      status: DsaReportStatus.pending,
+    );
+    _reports.insert(0, report);
+    return report;
+  }
+
+  @override
+  Future<List<DsaReportEntity>> getMyReports() async =>
+      List.unmodifiable(_reports);
+}

--- a/lib/features/profile/data/supabase/supabase_dsa_report_repository.dart
+++ b/lib/features/profile/data/supabase/supabase_dsa_report_repository.dart
@@ -1,0 +1,74 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:deelmarkt/features/profile/data/dto/dsa_report_dto.dart';
+import 'package:deelmarkt/features/profile/domain/entities/dsa_report_entity.dart';
+import 'package:deelmarkt/features/profile/domain/repositories/dsa_report_repository.dart';
+
+/// Supabase implementation of [DsaReportRepository].
+///
+/// [submit] calls the server-side `submit_dsa_report()` RPC (SECURITY INVOKER)
+/// which sets [slaDeadline] = now() + 24h and enforces one-report-per-target.
+/// [getMyReports] reads directly from [dsa_reports] — RLS limits rows to the
+/// authenticated user's own reports.
+///
+/// Reference: docs/epics/E06-trust-moderation.md §DSA Transparency Module
+/// Reference: docs/SPRINT-PLAN.md R-38
+class SupabaseDsaReportRepository implements DsaReportRepository {
+  const SupabaseDsaReportRepository(this._client);
+
+  final SupabaseClient _client;
+
+  static const _table = 'dsa_reports';
+
+  @override
+  Future<DsaReportEntity> submit({
+    required DsaTargetType targetType,
+    required String targetId,
+    required DsaReportCategory category,
+    required String description,
+  }) async {
+    final userId = _client.auth.currentUser?.id;
+    if (userId == null) {
+      throw Exception('User must be authenticated to submit a DSA report');
+    }
+
+    try {
+      final response = await _client.rpc(
+        'submit_dsa_report',
+        params: {
+          'p_target_type': DsaReportDto.targetTypeToDb(targetType),
+          'p_target_id': targetId,
+          'p_category': DsaReportDto.categoryToDb(category),
+          'p_description': description,
+        },
+      );
+
+      final rows = response as List<dynamic>;
+      if (rows.isEmpty) {
+        throw Exception('submit_dsa_report returned no rows');
+      }
+      return DsaReportDto.fromJson(rows.first as Map<String, dynamic>);
+    } on PostgrestException catch (e) {
+      throw Exception('Failed to submit DSA report: ${e.message}');
+    }
+  }
+
+  @override
+  Future<List<DsaReportEntity>> getMyReports() async {
+    final userId = _client.auth.currentUser?.id;
+    if (userId == null) {
+      throw Exception('User must be authenticated to fetch DSA reports');
+    }
+
+    try {
+      final response = await _client
+          .from(_table)
+          .select()
+          .order('reported_at', ascending: false);
+
+      return DsaReportDto.fromJsonList(response as List<dynamic>);
+    } on PostgrestException catch (e) {
+      throw Exception('Failed to fetch DSA reports: ${e.message}');
+    }
+  }
+}

--- a/lib/features/profile/domain/entities/dsa_report_entity.dart
+++ b/lib/features/profile/domain/entities/dsa_report_entity.dart
@@ -1,0 +1,80 @@
+/// What type of content is being reported.
+/// Matches the `dsa_target_t` DB enum (migration R-38).
+enum DsaTargetType { listing, message, profile, review }
+
+/// DSA Art. 16 notice category.
+/// Matches the `dsa_category_t` DB enum (migration R-38).
+enum DsaReportCategory {
+  illegalContent,
+  prohibitedItem,
+  counterfeit,
+  fraud,
+  privacyViolation,
+  other,
+}
+
+/// Lifecycle status of a DSA notice-and-action report.
+/// Matches the `dsa_status_t` DB enum (migration R-38).
+enum DsaReportStatus { pending, underReview, actioned, rejected }
+
+/// A user-filed DSA notice-and-action report against platform content.
+///
+/// The 24-hour SLA is tracked server-side via [slaDeadline].
+/// [isSlaBreached] is a UI hint only — the authoritative overdue query is the
+/// server-side `get_overdue_dsa_reports()` RPC (used by the admin dashboard).
+///
+/// Reference: docs/epics/E06-trust-moderation.md §DSA Transparency Module
+/// Reference: docs/SPRINT-PLAN.md R-38
+class DsaReportEntity {
+  const DsaReportEntity({
+    required this.id,
+    required this.targetType,
+    required this.targetId,
+    required this.category,
+    required this.description,
+    required this.reportedAt,
+    required this.slaDeadline,
+    required this.status,
+    this.reporterId,
+    this.reviewedBy,
+    this.reviewedAt,
+    this.resolutionNotes,
+  });
+
+  final String id;
+  final String? reporterId;
+  final DsaTargetType targetType;
+  final String targetId;
+  final DsaReportCategory category;
+  final String description;
+  final DateTime reportedAt;
+
+  /// Server-set to `reported_at + 24 hours`.
+  final DateTime slaDeadline;
+
+  final DsaReportStatus status;
+  final String? reviewedBy;
+  final DateTime? reviewedAt;
+  final String? resolutionNotes;
+
+  /// UI hint: SLA has passed and report is still open.
+  /// The authoritative check is `get_overdue_dsa_reports()` (service_role).
+  bool get isSlaBreached =>
+      DateTime.now().isAfter(slaDeadline) &&
+      (status == DsaReportStatus.pending ||
+          status == DsaReportStatus.underReview);
+
+  bool get isOpen =>
+      status == DsaReportStatus.pending ||
+      status == DsaReportStatus.underReview;
+
+  bool get isClosed =>
+      status == DsaReportStatus.actioned || status == DsaReportStatus.rejected;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is DsaReportEntity && other.id == id;
+
+  @override
+  int get hashCode => id.hashCode;
+}

--- a/lib/features/profile/domain/repositories/dsa_report_repository.dart
+++ b/lib/features/profile/domain/repositories/dsa_report_repository.dart
@@ -1,0 +1,22 @@
+import 'package:deelmarkt/features/profile/domain/entities/dsa_report_entity.dart';
+
+/// Repository interface for DSA notice-and-action reports.
+///
+/// Reference: docs/epics/E06-trust-moderation.md §DSA Transparency Module
+/// Reference: docs/SPRINT-PLAN.md R-38
+abstract class DsaReportRepository {
+  /// Files a DSA notice-and-action report against [targetType]/[targetId].
+  ///
+  /// Idempotent: a second call for the same (reporter, target) pair returns the
+  /// existing report without creating a duplicate.
+  Future<DsaReportEntity> submit({
+    required DsaTargetType targetType,
+    required String targetId,
+    required DsaReportCategory category,
+    required String description,
+  });
+
+  /// Returns all DSA reports filed by the current authenticated user,
+  /// ordered newest first.
+  Future<List<DsaReportEntity>> getMyReports();
+}

--- a/supabase/migrations/20260410120000_r38_dsa_reports.sql
+++ b/supabase/migrations/20260410120000_r38_dsa_reports.sql
@@ -1,0 +1,214 @@
+-- R-38: DSA notice-and-action reporting table + 24-hour SLA tracking
+-- Implements E06-trust-moderation.md §DSA Transparency Module.
+--
+-- Key design decisions:
+-- 1. report INSERT is exposed via submit_dsa_report() RPC (SECURITY INVOKER).
+--    All moderator UPDATEs (status, resolution) go via service_role.
+-- 2. target_id is a plain UUID (no FK). Reports can target listings, messages,
+--    profiles, or reviews — a polymorphic FK is impractical; application logic
+--    enforces that the referenced row exists before submission.
+-- 3. sla_deadline = reported_at + 24h, set server-side in the RPC.
+--    The get_overdue_dsa_reports() function is the canonical SLA query for the
+--    admin dashboard; never rely on client-side clock for SLA status.
+-- 4. One report per (reporter, target) pair per day to throttle abuse.
+--    Additional submissions within 24h return the existing row (idempotent RPC).
+-- 5. Reviewed_by ON DELETE SET NULL — preserves audit trail on moderator offboarding.
+--
+-- Reference: docs/epics/E06-trust-moderation.md §DSA Transparency Module
+-- Reference: docs/SPRINT-PLAN.md R-38
+
+-- =============================================================================
+-- 1. ENUMs
+-- =============================================================================
+
+CREATE TYPE dsa_target_t AS ENUM (
+  'listing',
+  'message',
+  'profile',
+  'review'
+);
+
+CREATE TYPE dsa_category_t AS ENUM (
+  'illegal_content',    -- CSAM, terrorism, hate speech (DSA Art. 3(h))
+  'prohibited_item',    -- Platform-policy prohibited goods
+  'counterfeit',        -- Fake branded goods
+  'fraud',              -- Scam listings / fake transactions
+  'privacy_violation',  -- Personal data shared without consent
+  'other'
+);
+
+CREATE TYPE dsa_status_t AS ENUM (
+  'pending',       -- Newly filed, not yet assigned
+  'under_review',  -- Moderator assigned and reviewing
+  'actioned',      -- Content removed / user sanctioned
+  'rejected'       -- Report found to be unfounded
+);
+
+-- =============================================================================
+-- 2. dsa_reports table
+-- =============================================================================
+
+CREATE TABLE dsa_reports (
+  id              UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Reporter (nullable on CASCADE delete so history survives account deletion)
+  reporter_id     UUID          REFERENCES auth.users(id) ON DELETE SET NULL,
+
+  -- What is being reported
+  target_type     dsa_target_t  NOT NULL,
+  target_id       UUID          NOT NULL,
+
+  -- DSA report category (Art. 16 notice-and-action)
+  category        dsa_category_t NOT NULL,
+
+  -- Plain-language description (required — vague reports are rejected)
+  description     TEXT          NOT NULL CHECK (length(trim(description)) >= 10),
+
+  -- Timestamps
+  reported_at     TIMESTAMPTZ   NOT NULL DEFAULT now(),
+
+  -- SLA deadline: 24 hours from reported_at (enforced by platform policy + DSA)
+  sla_deadline    TIMESTAMPTZ   NOT NULL,
+
+  -- Lifecycle status
+  status          dsa_status_t  NOT NULL DEFAULT 'pending',
+
+  -- Resolution fields — updated by moderator via service_role
+  reviewed_by     UUID          REFERENCES auth.users(id) ON DELETE SET NULL,
+  reviewed_at     TIMESTAMPTZ,
+  resolution_notes TEXT,
+
+  updated_at      TIMESTAMPTZ,
+
+  -- sla_deadline must be exactly 24h after reported_at
+  CONSTRAINT dsa_sla_deadline_check
+    CHECK (sla_deadline = reported_at + INTERVAL '24 hours'),
+
+  -- Resolution requires a reviewer
+  CONSTRAINT dsa_resolution_requires_reviewer
+    CHECK (reviewed_at IS NULL OR reviewed_by IS NOT NULL),
+
+  -- Unique per (reporter, target) per day — throttle abuse
+  CONSTRAINT dsa_one_report_per_target_per_day
+    UNIQUE NULLS NOT DISTINCT (reporter_id, target_id, target_type)
+);
+
+CREATE INDEX idx_dsa_reports_reporter ON dsa_reports (reporter_id, reported_at DESC);
+
+-- SLA monitoring index: fast lookup for overdue pending/in-review reports
+CREATE INDEX idx_dsa_reports_sla ON dsa_reports (sla_deadline, status)
+  WHERE status IN ('pending', 'under_review');
+
+-- =============================================================================
+-- 3. updated_at trigger
+-- =============================================================================
+-- Reuses update_updated_at() defined in 20260321232641.
+
+CREATE TRIGGER dsa_reports_updated_at
+  BEFORE UPDATE ON dsa_reports
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- =============================================================================
+-- 4. RLS — dsa_reports
+-- =============================================================================
+
+ALTER TABLE dsa_reports ENABLE ROW LEVEL SECURITY;
+
+-- Reporters can read their own reports (to show submission history + status).
+CREATE POLICY dsa_reports_own_select ON dsa_reports
+  FOR SELECT USING (reporter_id = auth.uid());
+
+-- INSERT is handled by submit_dsa_report() RPC (SECURITY INVOKER).
+-- All other mutations (UPDATE status, resolution) are service_role-only.
+
+-- =============================================================================
+-- 5. RPC: submit_dsa_report
+-- =============================================================================
+-- Authenticated users file a DSA notice-and-action report.
+-- Idempotent: if the same (reporter, target_type, target_id) pair exists,
+-- returns the existing row without inserting a duplicate (per the UNIQUE
+-- constraint + ON CONFLICT DO NOTHING).
+--
+-- Sets sla_deadline = now() + 24h server-side.
+-- Returns the inserted (or existing) report row.
+
+CREATE OR REPLACE FUNCTION submit_dsa_report(
+  p_target_type  dsa_target_t,
+  p_target_id    UUID,
+  p_category     dsa_category_t,
+  p_description  TEXT
+)
+RETURNS SETOF dsa_reports
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_user_id   UUID := auth.uid();
+  v_now       TIMESTAMPTZ := now();
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'User must be authenticated to submit a DSA report';
+  END IF;
+
+  IF p_description IS NULL OR length(trim(p_description)) < 10 THEN
+    RAISE EXCEPTION 'Report description must be at least 10 characters';
+  END IF;
+
+  -- Insert; silently ignore if the same (reporter, target) already reported.
+  INSERT INTO public.dsa_reports (
+    reporter_id,
+    target_type,
+    target_id,
+    category,
+    description,
+    reported_at,
+    sla_deadline
+  )
+  VALUES (
+    v_user_id,
+    p_target_type,
+    p_target_id,
+    p_category,
+    p_description,
+    v_now,
+    v_now + INTERVAL '24 hours'
+  )
+  ON CONFLICT (reporter_id, target_id, target_type) DO NOTHING;
+
+  RETURN QUERY
+    SELECT * FROM public.dsa_reports
+    WHERE reporter_id = v_user_id
+      AND target_id   = p_target_id
+      AND target_type = p_target_type
+    ORDER BY reported_at DESC
+    LIMIT 1;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION submit_dsa_report(dsa_target_t, UUID, dsa_category_t, TEXT) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION submit_dsa_report(dsa_target_t, UUID, dsa_category_t, TEXT) TO authenticated;
+
+-- =============================================================================
+-- 6. RPC: get_overdue_dsa_reports
+-- =============================================================================
+-- Returns all reports that have breached the 24-hour SLA and are still open.
+-- Used by the admin moderation dashboard (Retool / service_role).
+-- Not exposed to authenticated or anon roles.
+
+CREATE OR REPLACE FUNCTION get_overdue_dsa_reports()
+RETURNS SETOF dsa_reports
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM   public.dsa_reports
+  WHERE  sla_deadline < now()
+    AND  status IN ('pending', 'under_review')
+  ORDER  BY sla_deadline ASC;
+$$;
+
+REVOKE ALL ON FUNCTION get_overdue_dsa_reports() FROM PUBLIC;
+-- Intentionally not granted to authenticated — service_role only (admin panel).

--- a/test/features/profile/data/dto/dsa_report_dto_test.dart
+++ b/test/features/profile/data/dto/dsa_report_dto_test.dart
@@ -1,0 +1,215 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:deelmarkt/features/profile/data/dto/dsa_report_dto.dart';
+import 'package:deelmarkt/features/profile/domain/entities/dsa_report_entity.dart';
+
+Map<String, dynamic> _validJson({
+  String id = 'report-001',
+  String? reporterId = 'user-001',
+  String targetType = 'listing',
+  String targetId = 'listing-001',
+  String category = 'fraud',
+  String description = 'This is a scam listing with fake goods.',
+  String reportedAt = '2026-04-10T10:00:00Z',
+  String slaDeadline = '2026-04-11T10:00:00Z',
+  String status = 'pending',
+  String? reviewedBy,
+  String? reviewedAt,
+  String? resolutionNotes,
+}) => {
+  'id': id,
+  if (reporterId != null) 'reporter_id': reporterId,
+  'target_type': targetType,
+  'target_id': targetId,
+  'category': category,
+  'description': description,
+  'reported_at': reportedAt,
+  'sla_deadline': slaDeadline,
+  'status': status,
+  if (reviewedBy != null) 'reviewed_by': reviewedBy,
+  if (reviewedAt != null) 'reviewed_at': reviewedAt,
+  if (resolutionNotes != null) 'resolution_notes': resolutionNotes,
+};
+
+void main() {
+  group('DsaReportDto.fromJson — happy paths', () {
+    test('parses minimal valid report', () {
+      final result = DsaReportDto.fromJson(_validJson());
+
+      expect(result, isA<DsaReportEntity>());
+      expect(result.id, 'report-001');
+      expect(result.reporterId, 'user-001');
+      expect(result.targetType, DsaTargetType.listing);
+      expect(result.targetId, 'listing-001');
+      expect(result.category, DsaReportCategory.fraud);
+      expect(result.status, DsaReportStatus.pending);
+    });
+
+    test('parses all target types', () {
+      for (final t in ['listing', 'message', 'profile', 'review']) {
+        final result = DsaReportDto.fromJson(_validJson(targetType: t));
+        expect(result.targetType, isA<DsaTargetType>());
+      }
+    });
+
+    test('parses all categories', () {
+      final cats = [
+        'illegal_content',
+        'prohibited_item',
+        'counterfeit',
+        'fraud',
+        'privacy_violation',
+        'other',
+      ];
+      for (final c in cats) {
+        final result = DsaReportDto.fromJson(_validJson(category: c));
+        expect(result.category, isA<DsaReportCategory>());
+      }
+    });
+
+    test('parses all statuses', () {
+      for (final s in ['pending', 'under_review', 'actioned', 'rejected']) {
+        final result = DsaReportDto.fromJson(_validJson(status: s));
+        expect(result.status, isA<DsaReportStatus>());
+      }
+    });
+
+    test('parses resolution fields when present', () {
+      final result = DsaReportDto.fromJson(
+        _validJson(
+          status: 'actioned',
+          reviewedBy: 'mod-001',
+          reviewedAt: '2026-04-10T18:00:00Z',
+          resolutionNotes: 'Listing removed.',
+        ),
+      );
+
+      expect(result.reviewedBy, 'mod-001');
+      expect(result.reviewedAt, isNotNull);
+      expect(result.resolutionNotes, 'Listing removed.');
+    });
+
+    test('null reporter_id parses as null', () {
+      final json = _validJson(reporterId: null);
+      expect(DsaReportDto.fromJson(json).reporterId, isNull);
+    });
+
+    test('slaDeadline parsed correctly', () {
+      final result = DsaReportDto.fromJson(_validJson());
+      expect(result.slaDeadline.isAfter(result.reportedAt), true);
+    });
+  });
+
+  group('DsaReportDto.fromJson — error paths', () {
+    test('throws FormatException for missing id', () {
+      final json = _validJson()..remove('id');
+      expect(() => DsaReportDto.fromJson(json), throwsFormatException);
+    });
+
+    test('throws FormatException for missing target_type', () {
+      final json = _validJson()..remove('target_type');
+      expect(() => DsaReportDto.fromJson(json), throwsFormatException);
+    });
+
+    test('throws FormatException for missing target_id', () {
+      final json = _validJson()..remove('target_id');
+      expect(() => DsaReportDto.fromJson(json), throwsFormatException);
+    });
+
+    test('throws FormatException for missing category', () {
+      final json = _validJson()..remove('category');
+      expect(() => DsaReportDto.fromJson(json), throwsFormatException);
+    });
+
+    test('throws FormatException for missing description', () {
+      final json = _validJson()..remove('description');
+      expect(() => DsaReportDto.fromJson(json), throwsFormatException);
+    });
+
+    test('throws FormatException for missing reported_at', () {
+      final json = _validJson()..remove('reported_at');
+      expect(() => DsaReportDto.fromJson(json), throwsFormatException);
+    });
+
+    test('throws FormatException for missing sla_deadline', () {
+      final json = _validJson()..remove('sla_deadline');
+      expect(() => DsaReportDto.fromJson(json), throwsFormatException);
+    });
+
+    test('throws FormatException for missing status', () {
+      final json = _validJson()..remove('status');
+      expect(() => DsaReportDto.fromJson(json), throwsFormatException);
+    });
+
+    test('throws FormatException for unknown target_type', () {
+      expect(
+        () => DsaReportDto.fromJson(_validJson(targetType: 'comment')),
+        throwsFormatException,
+      );
+    });
+
+    test('throws FormatException for unknown category', () {
+      expect(
+        () => DsaReportDto.fromJson(_validJson(category: 'spam')),
+        throwsFormatException,
+      );
+    });
+
+    test('throws FormatException for unknown status', () {
+      expect(
+        () => DsaReportDto.fromJson(_validJson(status: 'open')),
+        throwsFormatException,
+      );
+    });
+
+    test('throws FormatException for invalid reported_at', () {
+      expect(
+        () => DsaReportDto.fromJson(_validJson(reportedAt: 'not-a-date')),
+        throwsFormatException,
+      );
+    });
+  });
+
+  group('DsaReportDto.fromJsonList', () {
+    test('parses a valid list', () {
+      final list = [
+        _validJson(),
+        _validJson(id: 'report-002', status: 'actioned'),
+      ];
+      expect(DsaReportDto.fromJsonList(list).length, 2);
+    });
+
+    test('skips malformed entries', () {
+      final list = [
+        _validJson(),
+        <String, dynamic>{'id': 'bad'},
+      ];
+      expect(DsaReportDto.fromJsonList(list).length, 1);
+    });
+
+    test('skips non-map entries', () {
+      final list = ['not-a-map', 42, _validJson()];
+      expect(DsaReportDto.fromJsonList(list).length, 1);
+    });
+
+    test('returns empty list for empty input', () {
+      expect(DsaReportDto.fromJsonList([]), isEmpty);
+    });
+  });
+
+  group('DsaReportDto DB serialisation helpers', () {
+    test('targetTypeToDb round-trips all values', () {
+      for (final t in DsaTargetType.values) {
+        final db = DsaReportDto.targetTypeToDb(t);
+        expect(db, isNotEmpty);
+      }
+    });
+
+    test('categoryToDb round-trips all values', () {
+      for (final c in DsaReportCategory.values) {
+        final db = DsaReportDto.categoryToDb(c);
+        expect(db, isNotEmpty);
+      }
+    });
+  });
+}

--- a/test/features/profile/data/mock/mock_dsa_report_repository_test.dart
+++ b/test/features/profile/data/mock/mock_dsa_report_repository_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:deelmarkt/features/profile/data/mock/mock_dsa_report_repository.dart';
+import 'package:deelmarkt/features/profile/domain/entities/dsa_report_entity.dart';
+
+void main() {
+  group('MockDsaReportRepository — default (empty)', () {
+    late MockDsaReportRepository repository;
+
+    setUp(() {
+      repository = MockDsaReportRepository();
+    });
+
+    test('getMyReports returns empty list', () async {
+      expect(await repository.getMyReports(), isEmpty);
+    });
+
+    test('submit returns a DsaReportEntity with correct fields', () async {
+      final result = await repository.submit(
+        targetType: DsaTargetType.listing,
+        targetId: 'listing-001',
+        category: DsaReportCategory.fraud,
+        description: 'This is a suspicious listing.',
+      );
+
+      expect(result, isA<DsaReportEntity>());
+      expect(result.targetType, DsaTargetType.listing);
+      expect(result.targetId, 'listing-001');
+      expect(result.category, DsaReportCategory.fraud);
+      expect(result.status, DsaReportStatus.pending);
+      expect(result.slaDeadline.isAfter(result.reportedAt), true);
+    });
+
+    test('submit adds report to getMyReports result', () async {
+      await repository.submit(
+        targetType: DsaTargetType.listing,
+        targetId: 'listing-001',
+        category: DsaReportCategory.fraud,
+        description: 'Suspicious listing.',
+      );
+
+      final reports = await repository.getMyReports();
+      expect(reports.length, 1);
+    });
+  });
+
+  group('MockDsaReportRepository — idempotency', () {
+    late MockDsaReportRepository repository;
+
+    setUp(() {
+      repository = MockDsaReportRepository();
+    });
+
+    test('second submit for same target returns existing report', () async {
+      final first = await repository.submit(
+        targetType: DsaTargetType.listing,
+        targetId: 'listing-001',
+        category: DsaReportCategory.fraud,
+        description: 'Suspicious listing.',
+      );
+      final second = await repository.submit(
+        targetType: DsaTargetType.listing,
+        targetId: 'listing-001',
+        category: DsaReportCategory.counterfeit,
+        description: 'Same listing, different reason.',
+      );
+
+      expect(first.id, second.id);
+      expect(await repository.getMyReports(), hasLength(1));
+    });
+
+    test('different target_id creates a new report', () async {
+      await repository.submit(
+        targetType: DsaTargetType.listing,
+        targetId: 'listing-001',
+        category: DsaReportCategory.fraud,
+        description: 'First report.',
+      );
+      await repository.submit(
+        targetType: DsaTargetType.listing,
+        targetId: 'listing-002',
+        category: DsaReportCategory.counterfeit,
+        description: 'Second report.',
+      );
+
+      expect(await repository.getMyReports(), hasLength(2));
+    });
+  });
+
+  group('MockDsaReportRepository — preloaded', () {
+    test('getMyReports returns preloaded reports', () async {
+      final now = DateTime.now();
+      final preloaded = [
+        DsaReportEntity(
+          id: 'pre-1',
+          targetType: DsaTargetType.profile,
+          targetId: 'user-001',
+          category: DsaReportCategory.other,
+          description: 'Fake profile.',
+          reportedAt: now,
+          slaDeadline: now.add(const Duration(hours: 24)),
+          status: DsaReportStatus.underReview,
+        ),
+      ];
+      final repository = MockDsaReportRepository(preloadedReports: preloaded);
+
+      final reports = await repository.getMyReports();
+      expect(reports.length, 1);
+      expect(reports.first.id, 'pre-1');
+    });
+  });
+}

--- a/test/features/profile/data/supabase/supabase_dsa_report_repository_test.dart
+++ b/test/features/profile/data/supabase/supabase_dsa_report_repository_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:deelmarkt/features/profile/data/supabase/supabase_dsa_report_repository.dart';
+import 'package:deelmarkt/features/profile/domain/entities/dsa_report_entity.dart';
+
+/// Minimal unauthenticated Supabase client for auth-guard tests.
+/// All RPC/table calls will throw — we only verify the auth check fires.
+SupabaseClient _unauthClient() =>
+    SupabaseClient('https://test.supabase.co', 'test-anon-key');
+
+void main() {
+  late SupabaseDsaReportRepository repository;
+
+  setUp(() {
+    repository = SupabaseDsaReportRepository(_unauthClient());
+  });
+
+  group('submit — auth guard', () {
+    test('throws when user is not authenticated', () async {
+      await expectLater(
+        () => repository.submit(
+          targetType: DsaTargetType.listing,
+          targetId: 'listing-001',
+          category: DsaReportCategory.fraud,
+          description: 'Suspicious listing',
+        ),
+        throwsA(anything),
+      );
+    });
+  });
+
+  group('getMyReports — auth guard', () {
+    test('throws when user is not authenticated', () async {
+      await expectLater(() => repository.getMyReports(), throwsA(anything));
+    });
+  });
+
+  group('DsaReportEntity business logic (no Supabase required)', () {
+    test('pending report within SLA is not breached', () {
+      final now = DateTime.now();
+      final report = DsaReportEntity(
+        id: 'r1',
+        targetType: DsaTargetType.listing,
+        targetId: 'l1',
+        category: DsaReportCategory.fraud,
+        description: 'Test report',
+        reportedAt: now,
+        slaDeadline: now.add(const Duration(hours: 20)),
+        status: DsaReportStatus.pending,
+      );
+      expect(report.isSlaBreached, false);
+      expect(report.isOpen, true);
+    });
+
+    test('pending report past SLA is breached', () {
+      final now = DateTime.now();
+      final report = DsaReportEntity(
+        id: 'r2',
+        targetType: DsaTargetType.listing,
+        targetId: 'l1',
+        category: DsaReportCategory.fraud,
+        description: 'Test report',
+        reportedAt: now.subtract(const Duration(hours: 26)),
+        slaDeadline: now.subtract(const Duration(hours: 2)),
+        status: DsaReportStatus.pending,
+      );
+      expect(report.isSlaBreached, true);
+    });
+
+    test('actioned report is never SLA breached', () {
+      final now = DateTime.now();
+      final report = DsaReportEntity(
+        id: 'r3',
+        targetType: DsaTargetType.message,
+        targetId: 'm1',
+        category: DsaReportCategory.illegalContent,
+        description: 'Illegal content in message',
+        reportedAt: now.subtract(const Duration(hours: 30)),
+        slaDeadline: now.subtract(const Duration(hours: 6)),
+        status: DsaReportStatus.actioned,
+        reviewedAt: now.subtract(const Duration(hours: 10)),
+      );
+      expect(report.isSlaBreached, false);
+      expect(report.isClosed, true);
+    });
+
+    test('rejected report is closed', () {
+      final now = DateTime.now();
+      final report = DsaReportEntity(
+        id: 'r4',
+        targetType: DsaTargetType.review,
+        targetId: 'rv1',
+        category: DsaReportCategory.other,
+        description: 'Report reason',
+        reportedAt: now,
+        slaDeadline: now.add(const Duration(hours: 24)),
+        status: DsaReportStatus.rejected,
+      );
+      expect(report.isClosed, true);
+      expect(report.isOpen, false);
+    });
+  });
+}

--- a/test/features/profile/domain/entities/dsa_report_entity_test.dart
+++ b/test/features/profile/domain/entities/dsa_report_entity_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:deelmarkt/features/profile/domain/entities/dsa_report_entity.dart';
+
+DsaReportEntity _make({
+  String id = 'r1',
+  DsaTargetType targetType = DsaTargetType.listing,
+  String targetId = 'listing-001',
+  DsaReportCategory category = DsaReportCategory.fraud,
+  String description = 'Scam listing',
+  DateTime? reportedAt,
+  DateTime? slaDeadline,
+  DsaReportStatus status = DsaReportStatus.pending,
+  DateTime? reviewedAt,
+  String? resolutionNotes,
+}) {
+  final now = reportedAt ?? DateTime.now().subtract(const Duration(hours: 1));
+  return DsaReportEntity(
+    id: id,
+    targetType: targetType,
+    targetId: targetId,
+    category: category,
+    description: description,
+    reportedAt: now,
+    slaDeadline: slaDeadline ?? now.add(const Duration(hours: 24)),
+    status: status,
+    reviewedAt: reviewedAt,
+    resolutionNotes: resolutionNotes,
+  );
+}
+
+void main() {
+  group('DsaReportEntity.isSlaBreached', () {
+    test('false when sla_deadline is in the future', () {
+      final report = _make(
+        slaDeadline: DateTime.now().add(const Duration(hours: 20)),
+      );
+      expect(report.isSlaBreached, false);
+    });
+
+    test('true when sla_deadline passed and status is pending', () {
+      final report = _make(
+        reportedAt: DateTime.now().subtract(const Duration(hours: 26)),
+        slaDeadline: DateTime.now().subtract(const Duration(hours: 2)),
+        // status defaults to pending
+      );
+      expect(report.isSlaBreached, true);
+    });
+
+    test('true when sla_deadline passed and status is under_review', () {
+      final report = _make(
+        slaDeadline: DateTime.now().subtract(const Duration(hours: 1)),
+        status: DsaReportStatus.underReview,
+      );
+      expect(report.isSlaBreached, true);
+    });
+
+    test('false when sla_deadline passed but report is actioned', () {
+      final report = _make(
+        slaDeadline: DateTime.now().subtract(const Duration(hours: 1)),
+        status: DsaReportStatus.actioned,
+      );
+      expect(report.isSlaBreached, false);
+    });
+
+    test('false when sla_deadline passed but report is rejected', () {
+      final report = _make(
+        slaDeadline: DateTime.now().subtract(const Duration(hours: 1)),
+        status: DsaReportStatus.rejected,
+      );
+      expect(report.isSlaBreached, false);
+    });
+  });
+
+  group('DsaReportEntity.isOpen / isClosed', () {
+    test('pending is open', () {
+      // status defaults to pending in _make
+      expect(_make().isOpen, true);
+      expect(_make().isClosed, false);
+    });
+
+    test('under_review is open', () {
+      expect(_make(status: DsaReportStatus.underReview).isOpen, true);
+      expect(_make(status: DsaReportStatus.underReview).isClosed, false);
+    });
+
+    test('actioned is closed', () {
+      expect(_make(status: DsaReportStatus.actioned).isOpen, false);
+      expect(_make(status: DsaReportStatus.actioned).isClosed, true);
+    });
+
+    test('rejected is closed', () {
+      expect(_make(status: DsaReportStatus.rejected).isOpen, false);
+      expect(_make(status: DsaReportStatus.rejected).isClosed, true);
+    });
+  });
+
+  group('DsaReportEntity equality', () {
+    test('same id → equal', () {
+      final a = _make(id: 'x');
+      final b = _make(id: 'x', status: DsaReportStatus.actioned);
+      expect(a, equals(b));
+    });
+
+    test('different id → not equal', () {
+      expect(_make(id: 'a'), isNot(equals(_make(id: 'b'))));
+    });
+
+    test('hashCode consistent with equality', () {
+      final a = _make(id: 'z');
+      final b = _make(id: 'z');
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+
+  group('DsaTargetType enum values', () {
+    test('all four values exist', () {
+      expect(DsaTargetType.values.length, 4);
+      expect(
+        DsaTargetType.values,
+        containsAll([
+          DsaTargetType.listing,
+          DsaTargetType.message,
+          DsaTargetType.profile,
+          DsaTargetType.review,
+        ]),
+      );
+    });
+  });
+
+  group('DsaReportCategory enum values', () {
+    test('all six values exist', () {
+      expect(DsaReportCategory.values.length, 6);
+    });
+  });
+
+  group('DsaReportStatus enum values', () {
+    test('all four values exist', () {
+      expect(DsaReportStatus.values.length, 4);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- **Migration** `20260410120000_r38_dsa_reports.sql`: `dsa_reports` table with `dsa_target_t` / `dsa_category_t` / `dsa_status_t` enums; `sla_deadline` enforced as `reported_at + 24h` via CHECK constraint; one-report-per-(reporter, target) UNIQUE constraint to throttle abuse
- **`submit_dsa_report()` RPC** (SECURITY INVOKER): validates auth + description ≥10 chars, sets `sla_deadline` server-side, idempotent via `ON CONFLICT DO NOTHING`
- **`get_overdue_dsa_reports()` RPC** (SECURITY DEFINER, service_role-only): returns all `pending`/`under_review` reports past their SLA — used by the admin moderation dashboard (Retool / P-40)
- **RLS**: reporters SELECT their own rows; all INSERT/UPDATE via RPC or service_role
- **Dart layer**: `DsaReportEntity` (isSlaBreached, isOpen, isClosed), `DsaReportRepository`, `DsaReportDto` (strict fromJson + debugPrint on skipped rows), `MockDsaReportRepository` (idempotent, preloadedReports), `SupabaseDsaReportRepository`, provider wired with `useMockDataProvider` gate
- **L10n**: `dsa_report.*` keys in EN + NL (title, all categories, all statuses, SLA breach label, a11y)
- **52 new tests** across entity, DTO, mock, and Supabase layers

## Epic alignment — E06 §DSA Transparency Module

| Criterion | Status |
|:----------|:-------|
| DSA notice-and-action form available and tracked with SLA | ✅ DB + RPC layer; UI tracked as P-40 (admin panel) |
| 24-hour SLA tracking | ✅ `sla_deadline` + `get_overdue_dsa_reports()` |

> **Backend-only PR.** The reporter-facing submission form and report history screen are UI tasks (P-40 or a new P task). The admin SLA dashboard is part of the Retool panel (P-40).

## Test plan

- [ ] `flutter test` — 52 new tests pass (entity, DTO, mock, Supabase auth-guard)
- [ ] `flutter analyze` — zero warnings
- [ ] SonarCloud coverage gate ≥80% on new code
- [ ] On merge: run `bash scripts/check_deployments.sh --deploy` to apply migration
- [ ] Flip R-38 checkbox in `docs/SPRINT-PLAN.md` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)