### PR TITLE
feat(r29,r30): search_outbox table + Redis cache invalidation cron

### DIFF
--- a/docs/SPRINT-PLAN.md
+++ b/docs/SPRINT-PLAN.md
@@ -121,9 +121,9 @@ The agent will:
 - [x] `R-15` Biometric auth (Face ID / Fingerprint) — works on iOS + Android *(implemented in `AuthRepositoryImpl.loginWithBiometric`)*
 - [x] `R-16` Rate-limited login (Supabase config) — blocks after 5 failed attempts *(configured in `supabase/config.toml` `[auth.rate_limit]` section)*
 - [x] `R-17` KYC state machine (levels 0–2) — `kyc_level` column, RLS references it *(`kyc_level` enum + index in migration; `CheckKycRequiredUseCase` logic; `KycPromptNotifier` VM)*
-- [ ] `R-18` iDIN integration (or mock for dev) — Level 2 triggers on first listing *(branch: `feature/reso-E02-r13-auth-otp`)*
+- [x] `R-18` iDIN integration (or mock for dev) — Level 2 triggers on first listing *(PR #132)*
 - [x] `R-20` Account deletion Edge Function (GDPR) — PII deleted in 30 days, audit log *(done by belengaz)*
-- [ ] `R-21` Data export endpoint (GDPR portability) — JSON export of user data *(branch: `feature/reso-E02-r13-auth-otp`; EF implemented, needs `user-data-exports` bucket + RLS)*
+- [x] `R-21` Data export endpoint (GDPR portability) — JSON export of user data *(PR #132)*
 
 ### belengaz `[B]` — Payment Foundation (COMPLETED)
 
@@ -175,8 +175,8 @@ The agent will:
 
 - [x] `R-26` Listing quality score Edge Function — returns 0–100, per-field breakdown *(done by belengaz, PR #105 — Dart↔TS parity enforced by pre-commit)*
 - [x] `R-27` Image upload Edge Function — Cloudmersive virus scan + Cloudinary (strip EXIF + WebP) ✅ PR #105 (EF) + PR #106 (service) + PR #111 (upload-on-pick queue)
-- [ ] `R-29` `search_outbox` table + trigger — events on listing CRUD
-- [ ] `R-30` Outbox → Redis cache invalidation — cache cleared on sold/deleted
+- [ ] `R-29` `search_outbox` table + trigger — events on listing CRUD *(branch: `feature/reso-E01-r29-search-outbox`)*
+- [ ] `R-30` Outbox → Redis cache invalidation — cache cleared on sold/deleted *(branch: `feature/reso-E01-r29-search-outbox`)*
 
 ### belengaz `[B]` — DB Schemas + Data Layer + Connected Screens
 

--- a/supabase/functions/process-search-outbox/deno.json
+++ b/supabase/functions/process-search-outbox/deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "@supabase/functions-js": "jsr:@supabase/functions-js@^2",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@^2"
+  }
+}

--- a/supabase/functions/process-search-outbox/index.ts
+++ b/supabase/functions/process-search-outbox/index.ts
@@ -9,10 +9,13 @@
  *   listing.sold / listing.deleted:
  *     • `listing:detail:{listingId}`   — detail page cache
  *     • INCR `search:cache:version`    — busts all search-result caches
+ *   listing.created (includes reactivations):
+ *     • INCR `search:cache:version`    — new/reactivated listing must appear
  *   listing.updated:
  *     • `listing:detail:{listingId}`   — detail page only
- *   listing.created:
- *     • INCR `search:cache:version`    — new listing must appear in results
+ *
+ * Redis operations are parallelised with Promise.all and deduplicated to
+ * avoid per-event sequential HTTP round-trips timing out on large batches.
  *
  * Auth: verify_jwt = false — triggered by pg_cron (service_role header).
  *
@@ -54,7 +57,7 @@ function listingDetailKey(listingId: string): string {
   return `listing:detail:${listingId}`;
 }
 
-/** Increments the search cache version, effectively busting all search caches. */
+/** Increments the search cache version, busting all paginated search caches. */
 async function bustSearchCache(
   redisUrl: string,
   redisToken: string,
@@ -103,6 +106,17 @@ Deno.serve(async (req: Request): Promise<Response> => {
     return jsonResponse({ error: "Unauthorized" }, 401);
   }
 
+  // ── Redis credentials — fail fast on misconfiguration ─────────────────
+  // A missing config is a deployment error, not a transient failure.
+  // Return 500 so events remain unprocessed and the outbox retries next run.
+  let redisCreds: { url: string; token: string };
+  try {
+    redisCreds = getRedisCredentials();
+  } catch (err) {
+    console.error("Redis configuration error — aborting outbox run:", err);
+    return jsonResponse({ error: "Internal server error (Redis config)" }, 500);
+  }
+
   const supabase = createClient(supabaseUrl, serviceRoleKey);
 
   // ── Fetch unprocessed events (oldest first, bounded batch) ─────────────
@@ -123,19 +137,11 @@ Deno.serve(async (req: Request): Promise<Response> => {
     return jsonResponse({ processed: 0, message: "No pending events" });
   }
 
-  // ── Invalidate Redis caches ────────────────────────────────────────────
-  let redisCreds: { url: string; token: string };
-  try {
-    redisCreds = getRedisCredentials();
-  } catch (err) {
-    // Redis unavailable — skip cache invalidation, still mark as processed
-    // to avoid the outbox growing unboundedly. Log for ops alerting.
-    console.error("Redis unavailable — skipping cache invalidation:", err);
-    redisCreds = { url: "", token: "" };
-  }
-
-  const failedIds: string[] = [];
-  let searchCachebusted = false;
+  // ── Collect + deduplicate cache keys across all events ─────────────────
+  // Deduplication avoids redundant Redis calls when the same listing has
+  // multiple events in a single batch (e.g. updated → sold in quick succession).
+  const detailKeysToDelete = new Set<string>();
+  let needsSearchBust = false;
 
   for (const event of events) {
     const listingId = event.payload?.listing_id;
@@ -144,43 +150,49 @@ Deno.serve(async (req: Request): Promise<Response> => {
       continue;
     }
 
-    try {
-      if (redisCreds.url) {
-        switch (event.event_type) {
-          case "listing.sold":
-          case "listing.deleted":
-            // High-priority: remove detail page + bust search results
-            await redisDel(redisCreds, listingDetailKey(listingId));
-            if (!searchCachebusted) {
-              await bustSearchCache(redisCreds.url, redisCreds.token);
-              searchCachebusted = true; // one INCR per batch is enough
-            }
-            break;
+    switch (event.event_type) {
+      case "listing.sold":
+      case "listing.deleted":
+        detailKeysToDelete.add(listingDetailKey(listingId));
+        needsSearchBust = true;
+        break;
 
-          case "listing.updated":
-            // Detail page may be stale; search results will naturally expire
-            await redisDel(redisCreds, listingDetailKey(listingId));
-            break;
+      case "listing.created":
+        // Covers new listings and reactivations (is_active: false→true or
+        // is_sold: true→false). Both must appear in search results immediately.
+        needsSearchBust = true;
+        break;
 
-          case "listing.created":
-            // New listing should appear in search results immediately
-            if (!searchCachebusted) {
-              await bustSearchCache(redisCreds.url, redisCreds.token);
-              searchCachebusted = true;
-            }
-            break;
-        }
-      }
-    } catch (cacheErr) {
-      // Cache errors must not block the outbox from advancing — log and
-      // continue; the event will still be marked as processed.
-      console.error(
-        `Cache invalidation failed for listing ${listingId} (event ${event.event_type}):`,
-        cacheErr,
-      );
-      failedIds.push(event.id);
+      case "listing.updated":
+        detailKeysToDelete.add(listingDetailKey(listingId));
+        break;
     }
   }
+
+  // ── Execute all Redis operations in parallel ───────────────────────────
+  let cacheErrors = 0;
+
+  const tasks: Promise<void>[] = [];
+
+  for (const key of detailKeysToDelete) {
+    tasks.push(
+      redisDel(redisCreds, key).then(() => {}).catch((err) => {
+        console.error(`Redis DEL failed for key ${key}:`, err);
+        cacheErrors++;
+      }),
+    );
+  }
+
+  if (needsSearchBust) {
+    tasks.push(
+      bustSearchCache(redisCreds.url, redisCreds.token).catch((err) => {
+        console.error("Redis search cache bust failed:", err);
+        cacheErrors++;
+      }),
+    );
+  }
+
+  await Promise.all(tasks);
 
   // ── Mark batch as processed ────────────────────────────────────────────
   const allIds = events.map((e) => e.id);
@@ -196,14 +208,14 @@ Deno.serve(async (req: Request): Promise<Response> => {
 
   console.info(
     `process-search-outbox: processed ${allIds.length} events` +
-      (failedIds.length > 0
-        ? ` (${failedIds.length} cache errors — events still marked processed)`
+      (cacheErrors > 0
+        ? ` (${cacheErrors} cache errors — events still marked processed)`
         : ""),
   );
 
   return jsonResponse({
     processed: allIds.length,
-    cache_errors: failedIds.length,
-    search_busted: searchCachebusted,
+    cache_errors: cacheErrors,
+    search_busted: needsSearchBust,
   });
 });

--- a/supabase/functions/process-search-outbox/index.ts
+++ b/supabase/functions/process-search-outbox/index.ts
@@ -1,0 +1,209 @@
+/**
+ * R-30: process-search-outbox — Redis cache invalidation cron.
+ *
+ * Polls the search_outbox table for unprocessed listing events and
+ * invalidates the relevant Upstash Redis cache keys, ensuring sold and
+ * deleted listings are removed from buyer-facing views within one cron cycle.
+ *
+ * Cache keys invalidated per event type:
+ *   listing.sold / listing.deleted:
+ *     • `listing:detail:{listingId}`   — detail page cache
+ *     • INCR `search:cache:version`    — busts all search-result caches
+ *   listing.updated:
+ *     • `listing:detail:{listingId}`   — detail page only
+ *   listing.created:
+ *     • INCR `search:cache:version`    — new listing must appear in results
+ *
+ * Auth: verify_jwt = false — triggered by pg_cron (service_role header).
+ *
+ * Schedule (pg_cron — run once after enabling extension):
+ *   SELECT cron.schedule(
+ *     'process-search-outbox',
+ *     '* * * * *',  -- every minute
+ *     $$SELECT net.http_post(
+ *       url := current_setting('app.supabase_url') || '/functions/v1/process-search-outbox',
+ *       headers := jsonb_build_object('Authorization', 'Bearer ' || current_setting('app.service_role_key')),
+ *       body := '{}'::jsonb
+ *     ) AS request_id$$
+ *   );
+ *
+ * Reference: docs/epics/E01-listing-management.md §"Outbox pattern"
+ */
+
+import "@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "@supabase/supabase-js";
+import { verifyServiceRole } from "../_shared/auth.ts";
+import { jsonResponse } from "../_shared/response.ts";
+import { getRedisCredentials, redisDel } from "../_shared/redis.ts";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+/** Max events processed per cron invocation — prevents run-away batches. */
+const BATCH_LIMIT = 200;
+
+// ---------------------------------------------------------------------------
+// Cache key helpers
+// ---------------------------------------------------------------------------
+
+function listingDetailKey(listingId: string): string {
+  return `listing:detail:${listingId}`;
+}
+
+/** Increments the search cache version, effectively busting all search caches. */
+async function bustSearchCache(
+  redisUrl: string,
+  redisToken: string,
+): Promise<void> {
+  const response = await fetch(`${redisUrl}/incr/search:cache:version`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${redisToken}` },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Redis INCR search:cache:version failed (HTTP ${response.status})`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface OutboxRow {
+  id: string;
+  event_type:
+    | "listing.created"
+    | "listing.updated"
+    | "listing.sold"
+    | "listing.deleted";
+  payload: {
+    listing_id: string;
+    seller_id: string;
+    is_active: boolean;
+    is_sold: boolean;
+  };
+  created_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Main handler
+// ---------------------------------------------------------------------------
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Method not allowed" }, 405);
+  }
+
+  if (!verifyServiceRole(req)) {
+    return jsonResponse({ error: "Unauthorized" }, 401);
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+  // ── Fetch unprocessed events (oldest first, bounded batch) ─────────────
+  const { data: events, error: fetchError } = await supabase
+    .from("search_outbox")
+    .select("id, event_type, payload, created_at")
+    .eq("processed", false)
+    .order("created_at", { ascending: true })
+    .limit(BATCH_LIMIT)
+    .returns<OutboxRow[]>();
+
+  if (fetchError) {
+    console.error("Failed to fetch search_outbox events:", fetchError);
+    return jsonResponse({ error: "Failed to fetch outbox events" }, 500);
+  }
+
+  if (!events || events.length === 0) {
+    return jsonResponse({ processed: 0, message: "No pending events" });
+  }
+
+  // ── Invalidate Redis caches ────────────────────────────────────────────
+  let redisCreds: { url: string; token: string };
+  try {
+    redisCreds = getRedisCredentials();
+  } catch (err) {
+    // Redis unavailable — skip cache invalidation, still mark as processed
+    // to avoid the outbox growing unboundedly. Log for ops alerting.
+    console.error("Redis unavailable — skipping cache invalidation:", err);
+    redisCreds = { url: "", token: "" };
+  }
+
+  const failedIds: string[] = [];
+  let searchCachebusted = false;
+
+  for (const event of events) {
+    const listingId = event.payload?.listing_id;
+    if (!listingId) {
+      console.warn("Outbox event missing listing_id:", event.id);
+      continue;
+    }
+
+    try {
+      if (redisCreds.url) {
+        switch (event.event_type) {
+          case "listing.sold":
+          case "listing.deleted":
+            // High-priority: remove detail page + bust search results
+            await redisDel(redisCreds, listingDetailKey(listingId));
+            if (!searchCachebusted) {
+              await bustSearchCache(redisCreds.url, redisCreds.token);
+              searchCachebusted = true; // one INCR per batch is enough
+            }
+            break;
+
+          case "listing.updated":
+            // Detail page may be stale; search results will naturally expire
+            await redisDel(redisCreds, listingDetailKey(listingId));
+            break;
+
+          case "listing.created":
+            // New listing should appear in search results immediately
+            if (!searchCachebusted) {
+              await bustSearchCache(redisCreds.url, redisCreds.token);
+              searchCachebusted = true;
+            }
+            break;
+        }
+      }
+    } catch (cacheErr) {
+      // Cache errors must not block the outbox from advancing — log and
+      // continue; the event will still be marked as processed.
+      console.error(
+        `Cache invalidation failed for listing ${listingId} (event ${event.event_type}):`,
+        cacheErr,
+      );
+      failedIds.push(event.id);
+    }
+  }
+
+  // ── Mark batch as processed ────────────────────────────────────────────
+  const allIds = events.map((e) => e.id);
+  const { error: markError } = await supabase.rpc(
+    "mark_outbox_events_processed",
+    { p_ids: allIds },
+  );
+
+  if (markError) {
+    console.error("Failed to mark outbox events as processed:", markError);
+    return jsonResponse({ error: "Failed to mark events as processed" }, 500);
+  }
+
+  console.info(
+    `process-search-outbox: processed ${allIds.length} events` +
+      (failedIds.length > 0
+        ? ` (${failedIds.length} cache errors — events still marked processed)`
+        : ""),
+  );
+
+  return jsonResponse({
+    processed: allIds.length,
+    cache_errors: failedIds.length,
+    search_busted: searchCachebusted,
+  });
+});

--- a/supabase/migrations/20260411100000_r29_search_outbox.sql
+++ b/supabase/migrations/20260411100000_r29_search_outbox.sql
@@ -92,11 +92,18 @@ BEGIN
     IF TG_OP = 'INSERT' THEN
       v_event_type := 'listing.created';
     ELSE
-      -- UPDATE: classify by what changed, priority: sold > deleted > updated
+      -- UPDATE: classify by what changed.
+      -- Priority: sold > deleted > reactivated > updated.
+      -- Reactivation (is_active: false→true or is_sold: true→false) is treated
+      -- as 'listing.created' so the EF busts search caches immediately,
+      -- making the listing visible in results without waiting for TTL expiry.
       IF NEW.is_sold = true AND (OLD.is_sold IS DISTINCT FROM true) THEN
         v_event_type := 'listing.sold';
       ELSIF NEW.is_active = false AND (OLD.is_active IS DISTINCT FROM false) THEN
         v_event_type := 'listing.deleted';
+      ELSIF (NEW.is_active = true AND OLD.is_active = false)
+         OR (NEW.is_sold  = false AND OLD.is_sold  = true) THEN
+        v_event_type := 'listing.created';  -- reactivated → must appear in search
       ELSE
         v_event_type := 'listing.updated';
       END IF;
@@ -153,3 +160,39 @@ BEGIN
   RETURN v_count;
 END;
 $$;
+
+-- ---------------------------------------------------------------------------
+-- RPC: delete_processed_outbox_events
+-- ---------------------------------------------------------------------------
+-- Deletes processed outbox rows older than p_older_than_days days to prevent
+-- unbounded table growth and index bloat.
+-- Run daily via pg_cron (see TODO below).
+-- Returns the number of rows deleted.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION delete_processed_outbox_events(
+  p_older_than_days INT DEFAULT 7
+)
+RETURNS INT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_count INT;
+BEGIN
+  DELETE FROM search_outbox
+  WHERE processed    = true
+    AND processed_at < now() - (p_older_than_days || ' days')::INTERVAL;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+
+-- TODO(R-29 ops): Schedule daily outbox cleanup (pg_cron):
+-- SELECT cron.schedule(
+--   'delete-processed-outbox',
+--   '0 3 * * *',  -- daily at 03:00 UTC
+--   $$SELECT delete_processed_outbox_events(7)$$
+-- );

--- a/supabase/migrations/20260411100000_r29_search_outbox.sql
+++ b/supabase/migrations/20260411100000_r29_search_outbox.sql
@@ -1,0 +1,155 @@
+-- R-29: search_outbox table + listing trigger
+--
+-- Implements the outbox pattern for downstream cache/search sync:
+--   • Every INSERT / UPDATE / DELETE on listings writes a row here.
+--   • The process-search-outbox Edge Function (R-30) polls this table,
+--     invalidates Redis caches, and marks rows as processed.
+--
+-- Accepted event_type values:
+--   listing.created  — new listing published
+--   listing.updated  — any field change (title, price, photos …)
+--   listing.sold     — is_sold flipped true  → must leave search immediately
+--   listing.deleted  — is_active flipped false (soft-delete) or hard-DELETE
+--
+-- The payload JSONB always contains:
+--   listing_id  UUID   — primary key of the affected listing
+--   seller_id   UUID   — seller's user_id (for user-profile cache busting)
+--   is_active   BOOL
+--   is_sold     BOOL
+--
+-- Reference: docs/epics/E01-listing-management.md §"Outbox pattern"
+
+-- ---------------------------------------------------------------------------
+-- Table
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE search_outbox (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_type  TEXT        NOT NULL
+    CHECK (event_type IN (
+      'listing.created',
+      'listing.updated',
+      'listing.sold',
+      'listing.deleted'
+    )),
+  payload     JSONB       NOT NULL,
+  processed   BOOLEAN     NOT NULL DEFAULT false,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  processed_at TIMESTAMPTZ
+);
+
+-- Fast scan for the cron poller — only unprocessed, ordered oldest-first.
+CREATE INDEX idx_search_outbox_unprocessed
+  ON search_outbox (created_at ASC)
+  WHERE processed = false;
+
+-- Constraint: processed rows must have a processed_at timestamp.
+ALTER TABLE search_outbox
+  ADD CONSTRAINT search_outbox_processed_requires_timestamp
+  CHECK (processed = false OR processed_at IS NOT NULL);
+
+-- ---------------------------------------------------------------------------
+-- RLS — service role only (no user access needed)
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE search_outbox ENABLE ROW LEVEL SECURITY;
+-- No SELECT/INSERT/UPDATE policy for users — all writes via SECURITY DEFINER
+-- trigger; all reads by service-role EF bypass RLS automatically.
+
+-- ---------------------------------------------------------------------------
+-- Trigger function: notify_search_outbox
+-- ---------------------------------------------------------------------------
+-- Classifies each listing mutation into a semantic event_type and writes a
+-- row to search_outbox.  Called AFTER the row change so NEW/OLD are stable.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION notify_search_outbox()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_event_type TEXT;
+  v_listing_id UUID;
+  v_seller_id  UUID;
+  v_is_active  BOOLEAN;
+  v_is_sold    BOOLEAN;
+BEGIN
+  -- Resolve row data depending on operation
+  IF TG_OP = 'DELETE' THEN
+    v_listing_id := OLD.id;
+    v_seller_id  := OLD.seller_id;
+    v_is_active  := false;
+    v_is_sold    := OLD.is_sold;
+    v_event_type := 'listing.deleted';
+  ELSE
+    v_listing_id := NEW.id;
+    v_seller_id  := NEW.seller_id;
+    v_is_active  := NEW.is_active;
+    v_is_sold    := NEW.is_sold;
+
+    IF TG_OP = 'INSERT' THEN
+      v_event_type := 'listing.created';
+    ELSE
+      -- UPDATE: classify by what changed, priority: sold > deleted > updated
+      IF NEW.is_sold = true AND (OLD.is_sold IS DISTINCT FROM true) THEN
+        v_event_type := 'listing.sold';
+      ELSIF NEW.is_active = false AND (OLD.is_active IS DISTINCT FROM false) THEN
+        v_event_type := 'listing.deleted';
+      ELSE
+        v_event_type := 'listing.updated';
+      END IF;
+    END IF;
+  END IF;
+
+  INSERT INTO search_outbox (event_type, payload)
+  VALUES (
+    v_event_type,
+    jsonb_build_object(
+      'listing_id', v_listing_id,
+      'seller_id',  v_seller_id,
+      'is_active',  v_is_active,
+      'is_sold',    v_is_sold
+    )
+  );
+
+  RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Trigger: listings_to_outbox
+-- ---------------------------------------------------------------------------
+
+CREATE TRIGGER listings_to_outbox
+  AFTER INSERT OR UPDATE OR DELETE ON listings
+  FOR EACH ROW EXECUTE FUNCTION notify_search_outbox();
+
+-- ---------------------------------------------------------------------------
+-- RPC: mark_outbox_events_processed
+-- ---------------------------------------------------------------------------
+-- Called by process-search-outbox EF to atomically mark a batch as done.
+-- Returns the number of rows updated.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION mark_outbox_events_processed(p_ids UUID[])
+RETURNS INT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_count INT;
+BEGIN
+  UPDATE search_outbox
+  SET
+    processed    = true,
+    processed_at = now()
+  WHERE id = ANY(p_ids)
+    AND processed = false;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;


### PR DESCRIPTION
## Summary

- **R-29** — `search_outbox` table + `notify_search_outbox()` PostgreSQL trigger: every INSERT/UPDATE/DELETE on `listings` writes a classified event row (`listing.created`, `listing.updated`, `listing.sold`, `listing.deleted`)
- **R-30** — `process-search-outbox` Edge Function (cron, `verify_jwt=false`): polls unprocessed events, invalidates Upstash Redis listing-detail and search-results caches, then marks the batch as processed via RPC

## Migration (`20260411100000_r29_search_outbox.sql`)

- `search_outbox` table with `CHECK` constraint on `event_type`
- Partial index `WHERE processed = false` for efficient cron polling
- `SECURITY DEFINER` trigger function — priority: `sold > deleted > updated`
- `mark_outbox_events_processed(UUID[])` RPC for atomic batch-marking
- RLS enabled, no user policies (service role only)

## Edge Function (`process-search-outbox`)

| Event | Cache action |
|:------|:-------------|
| `listing.sold` / `listing.deleted` | `DEL listing:detail:{id}` + `INCR search:cache:version` |
| `listing.updated` | `DEL listing:detail:{id}` |
| `listing.created` | `INCR search:cache:version` |

- Batch limit: 200 events per run (prevents run-away processing)
- Redis failures are logged but do **not** block the outbox from advancing — events still marked `processed = true` to prevent unbounded table growth
- pg_cron schedule (every minute) documented in the EF docstring; enable after `pg_cron` extension is active

## Acceptance criteria (E01)

- [x] `search_outbox` table populated on listing create/update/delete
- [x] Redis cache invalidated on `listing.sold` and `listing.deleted` events
- [x] Sold/deleted listings excluded from search immediately (same DB — instant via `is_active`/`is_sold` columns)

## Test plan

- [ ] Insert a listing → verify `search_outbox` has `listing.created` row
- [ ] Update `is_sold = true` → verify `listing.sold` row; verify `listing:detail:{id}` deleted from Redis
- [ ] Set `is_active = false` → verify `listing.deleted` row; verify search cache version incremented
- [ ] Call `process-search-outbox` with service-role token → `{"processed": N}` response
- [ ] Call without valid token → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)