### PR TITLE
fix(sell): add upload progress caption to PhotoStepView

### DIFF
--- a/lib/features/sell/presentation/widgets/photo_step/photo_step_view.dart
+++ b/lib/features/sell/presentation/widgets/photo_step/photo_step_view.dart
@@ -38,6 +38,25 @@ class PhotoStepView extends ConsumerWidget {
             ),
           ),
         ),
+        // Show upload progress caption when uploads are in progress (§3.8)
+        if (state.hasPendingUploads)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: Spacing.s4),
+            child: Semantics(
+              liveRegion: true,
+              child: Text(
+                'sell.uploadingProgress'.tr(
+                  namedArgs: {
+                    'current': '${state.uploadedCount}',
+                    'total': '${state.imageFiles.length}',
+                  },
+                ),
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          ),
         const SizedBox(height: Spacing.s3),
         Expanded(
           child: PhotoGrid(


### PR DESCRIPTION
## Summary

Addresses gemini-code-assist review finding from PR #134 (review 4094304678):

> **Medium priority:** The implementation of the photo step view is missing the upload progress caption (e.g., "Uploading 3 of 12 photos...") that was specified in the design plan (§3.8).

## Changes

- Added upload progress caption to `PhotoStepView` that displays when `hasPendingUploads` is true
- Shows "Uploading {current} of {total}" using existing l10n key `sell.uploadingProgress`
- Caption styled as `bodySmall` with `onSurfaceVariant` color
- Includes `Semantics` liveRegion for accessibility

## Other Review Findings (Already Addressed)

The other review findings from PR #134 are **already fixed** in the current codebase but the review threads weren't marked resolved:

| Finding | Status | Evidence |
|:--------|:------:|:---------|
| `photo_grid_tile.dart:64` - File/FileImage web compat | ✅ Already fixed | `kIsWeb` guard at lines 59-64 |
| `photo_grid_tile.dart:199` - Error text missing | ✅ Already fixed | `errorKey!.tr()` at lines 184-196 |
| `push_notification_service.dart` - Platform.isIOS | ✅ Already fixed (PR #137) | `if (kIsWeb)` block |
| `own_profile_screen.dart` - NestedScrollView | ✅ Already fixed (PR #137) | Uses `NestedScrollView` |

## Test Plan

- [x] Displays "Uploading X of Y" when uploads are in progress
- [x] Hidden when no uploads pending
- [x] Uses correct l10n key with named args
- [ ] CI passes

https://claude.ai/code/session_01SH1C49nKzJFeAJTn7ZLKih