### PR TITLE
fix(sell): PR #134 review fixes — l10n, TODO header, upload progress index

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -39,7 +39,8 @@ import 'package:deelmarkt/features/admin/presentation/screens/admin_shell_screen
 import 'package:deelmarkt/features/admin/presentation/screens/admin_dashboard_screen.dart';
 
 /// Placeholder for admin sub-screens not yet implemented (Phase B-D).
-const _adminComingSoon = Scaffold(body: Center(child: Text('Coming soon')));
+Widget _adminComingSoon(BuildContext context) =>
+    Scaffold(body: Center(child: Text('admin.comingSoon'.tr())));
 
 /// Central GoRouter configuration with deep link support + auth guard.
 ///
@@ -230,25 +231,25 @@ GoRouter _buildRouter({
           GoRoute(
             path: AppRoutes.adminFlaggedListings,
             name: 'admin-flagged-listings',
-            builder: (context, state) => _adminComingSoon,
+            builder: (context, state) => _adminComingSoon(context),
           ),
           GoRoute(
             path: AppRoutes.adminReportedUsers,
             name: 'admin-reported-users',
-            builder: (context, state) => _adminComingSoon,
+            builder: (context, state) => _adminComingSoon(context),
           ),
           GoRoute(
             path: AppRoutes.adminDisputes,
             name: 'admin-disputes',
-            builder: (context, state) => _adminComingSoon,
+            builder: (context, state) => _adminComingSoon(context),
             routes: [
               GoRoute(
                 path: ':id',
                 name: 'admin-dispute-detail',
                 redirect: _idGuard('id', AppRoutes.adminDisputes),
                 builder:
-                    (context, state) => const Scaffold(
-                      body: Center(child: Text('Coming soon')),
+                    (context, state) => Scaffold(
+                      body: Center(child: Text('admin.comingSoon'.tr())),
                     ),
               ),
             ],
@@ -256,12 +257,12 @@ GoRouter _buildRouter({
           GoRoute(
             path: AppRoutes.adminDsaNotices,
             name: 'admin-dsa-notices',
-            builder: (context, state) => _adminComingSoon,
+            builder: (context, state) => _adminComingSoon(context),
           ),
           GoRoute(
             path: AppRoutes.adminAppeals,
             name: 'admin-appeals',
-            builder: (context, state) => _adminComingSoon,
+            builder: (context, state) => _adminComingSoon(context),
           ),
         ],
       ),

--- a/lib/features/home/domain/entities/listing_entity.dart
+++ b/lib/features/home/domain/entities/listing_entity.dart
@@ -1,3 +1,4 @@
+// TODO(#133): File exceeds 100-line limit (151 lines). Decompose model.
 import 'package:equatable/equatable.dart';
 
 import 'package:deelmarkt/features/home/domain/entities/listing_condition.dart';

--- a/lib/features/sell/presentation/widgets/photo_step/photo_step_view.dart
+++ b/lib/features/sell/presentation/widgets/photo_step/photo_step_view.dart
@@ -40,22 +40,9 @@ class PhotoStepView extends ConsumerWidget {
         ),
         // Show upload progress caption when uploads are in progress (§3.8)
         if (state.hasPendingUploads)
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: Spacing.s4),
-            child: Semantics(
-              liveRegion: true,
-              child: Text(
-                'sell.uploadingProgress'.tr(
-                  namedArgs: {
-                    'current': '${state.uploadedCount}',
-                    'total': '${state.imageFiles.length}',
-                  },
-                ),
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
-                ),
-              ),
-            ),
+          _UploadProgressCaption(
+            uploadedCount: state.uploadedCount + 1,
+            total: state.imageFiles.length,
           ),
         const SizedBox(height: Spacing.s3),
         Expanded(
@@ -164,5 +151,44 @@ class PhotoStepView extends ConsumerWidget {
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text(message)));
+  }
+}
+
+/// Inline caption shown below the photo count while uploads are in progress.
+///
+/// Displays "Uploading X of N…" with a live-region so screen readers
+/// announce progress updates automatically (§10).
+class _UploadProgressCaption extends StatelessWidget {
+  const _UploadProgressCaption({
+    required this.uploadedCount,
+    required this.total,
+  });
+
+  /// 1-based count of the photo currently being uploaded.
+  final int uploadedCount;
+
+  /// Total number of photos in the current batch.
+  final int total;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(
+        left: Spacing.s4,
+        right: Spacing.s4,
+        top: Spacing.s1,
+      ),
+      child: Semantics(
+        liveRegion: true,
+        child: Text(
+          'sell.uploadingProgress'.tr(
+            namedArgs: {'current': '$uploadedCount', 'total': '$total'},
+          ),
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ),
+    );
   }
 }


### PR DESCRIPTION
## Summary

Addresses remaining findings from [@deelmarkt-dev review #4094304678](https://github.com/deelmarkt-org/app/pull/134#pullrequestreview-4094304678) on PR #134. Fix 1 (kIsWeb guard in `photo_upload_queue.dart`) was already shipped in PR #140.

- **Fix 2 (P0)** `app_router.dart` — Replace `const _adminComingSoon = Scaffold(body: Center(child: Text('Coming soon')))` with a function `Widget _adminComingSoon(BuildContext context)` that uses `'admin.comingSoon'.tr()`. Also fixes the inline `Text('Coming soon')` in the admin-dispute-detail route (6 occurrences total).
- **Fix 3 (P1)** `listing_entity.dart` — Add `// TODO(#133)` header (151 lines exceeds 100-line model limit per CLAUDE.md §2.1).
- **Fix 4 (P2)** `photo_step_view.dart` — Fix 0-based `uploadedCount` display (now shows "1 of N" for first photo); add `top: Spacing.s1` gap between photo count and progress caption; extract `_UploadProgressCaption` widget to keep `build()` under SonarCloud S3776's 60-line method limit.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test test/features/sell/` — 352 tests passed
- [x] Pre-commit hooks all passed (dart format, flutter analyze, quality check, SonarCloud proxy, flutter test)
- [x] Pre-push hooks all passed (strict analyze, coverage ≥80%)
- [x] `_adminComingSoon` now uses `.tr()` — no more hardcoded English strings in router
- [x] Upload progress shows "1 of 3" on first photo (not "0 of 3")
- [x] `_UploadProgressCaption` widget tested indirectly via existing `PhotoStepView` widget tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)