### PR TITLE
feat(profile): wire deferred nav tasks #50 #51 #52 #53 + Tier-1 audit fixes

### DIFF
--- a/assets/l10n/en-US.json
+++ b/assets/l10n/en-US.json
@@ -427,6 +427,8 @@
     "addAddress": "Add address",
     "editAddress": "Edit address",
     "addressSaved": "Address saved",
+    "deleteAddressTitle": "Delete address?",
+    "deleteAddressBody": "This address will be permanently deleted.",
     "notifications": "Notifications",
     "messages": "Messages",
     "offers": "Offers",
@@ -561,6 +563,8 @@
     "takePhoto": "Take a photo",
     "chooseFromGallery": "Choose from gallery",
     "photoSelected": "Photo selected",
+    "avatarUploading": "Uploading photo...",
+    "avatarUploadFailed": "Photo upload failed",
     "deletedUser": "Deleted user"
   },
   "review": {

--- a/assets/l10n/en-US.json
+++ b/assets/l10n/en-US.json
@@ -428,7 +428,6 @@
     "editAddress": "Edit address",
     "addressSaved": "Address saved",
     "deleteAddressTitle": "Delete address?",
-    "deleteAddressBody": "This address will be permanently deleted.",
     "notifications": "Notifications",
     "messages": "Messages",
     "offers": "Offers",

--- a/assets/l10n/nl-NL.json
+++ b/assets/l10n/nl-NL.json
@@ -306,6 +306,8 @@
     "addAddress": "Adres toevoegen",
     "editAddress": "Adres bewerken",
     "addressSaved": "Adres opgeslagen",
+    "deleteAddressTitle": "Adres verwijderen?",
+    "deleteAddressBody": "Dit adres wordt permanent verwijderd.",
     "notifications": "Meldingen",
     "messages": "Berichten",
     "offers": "Biedingen",
@@ -561,6 +563,8 @@
     "takePhoto": "Maak een foto",
     "chooseFromGallery": "Kies uit galerij",
     "photoSelected": "Foto geselecteerd",
+    "avatarUploading": "Foto uploaden...",
+    "avatarUploadFailed": "Foto uploaden mislukt",
     "deletedUser": "Verwijderde gebruiker"
   },
   "review": {

--- a/assets/l10n/nl-NL.json
+++ b/assets/l10n/nl-NL.json
@@ -307,7 +307,6 @@
     "editAddress": "Adres bewerken",
     "addressSaved": "Adres opgeslagen",
     "deleteAddressTitle": "Adres verwijderen?",
-    "deleteAddressBody": "Dit adres wordt permanent verwijderd.",
     "notifications": "Meldingen",
     "messages": "Berichten",
     "offers": "Biedingen",

--- a/docs/SPRINT-PLAN.md
+++ b/docs/SPRINT-PLAN.md
@@ -160,10 +160,10 @@ The agent will:
 | [#47](https://github.com/deelmarkt-org/app/issues/47) | ~~`[R]` Implement SupabaseSettingsRepository **(P0 launch blocker)**~~ | belengaz | — | ✅ PR #57 |
 | [#48](https://github.com/deelmarkt-org/app/issues/48) | `[R]` Wire iDIN to Edge Function | reso | R-18 iDIN integration | 3–4 |
 | [#49](https://github.com/deelmarkt-org/app/issues/49) | `[R]` 30-day soft-delete grace period | reso | — | 5–8 |
-| [#50](https://github.com/deelmarkt-org/app/issues/50) | `[P]` Wire address form navigation in Settings | pizmam | — | 5–8 |
-| [#51](https://github.com/deelmarkt-org/app/issues/51) | `[P]` Wire sell screen navigation from empty listings | pizmam | P-24 | 5–8 |
-| [#52](https://github.com/deelmarkt-org/app/issues/52) | `[P]` Wire listing detail navigation from profile | pizmam | B-51 | 5–8 |
-| [#53](https://github.com/deelmarkt-org/app/issues/53) | `[P]` Wire avatar picker navigation | pizmam | — | 9–10 |
+| [#50](https://github.com/deelmarkt-org/app/issues/50) | ~~`[P]` Wire address form navigation in Settings~~ | pizmam | — | ✅ PR #feature/pizmam-deferred-nav-wiring |
+| [#51](https://github.com/deelmarkt-org/app/issues/51) | ~~`[P]` Wire sell screen navigation from empty listings~~ | pizmam | P-24 | ✅ PR #feature/pizmam-deferred-nav-wiring |
+| [#52](https://github.com/deelmarkt-org/app/issues/52) | ~~`[P]` Wire listing detail navigation from profile~~ | pizmam | B-51 | ✅ PR #feature/pizmam-deferred-nav-wiring |
+| [#53](https://github.com/deelmarkt-org/app/issues/53) | ~~`[P]` Wire avatar picker navigation~~ | pizmam | — | ✅ PR #feature/pizmam-deferred-nav-wiring |
 
 ---
 

--- a/docs/SPRINT-PLAN.md
+++ b/docs/SPRINT-PLAN.md
@@ -160,10 +160,10 @@ The agent will:
 | [#47](https://github.com/deelmarkt-org/app/issues/47) | ~~`[R]` Implement SupabaseSettingsRepository **(P0 launch blocker)**~~ | belengaz | — | ✅ PR #57 |
 | [#48](https://github.com/deelmarkt-org/app/issues/48) | `[R]` Wire iDIN to Edge Function | reso | R-18 iDIN integration | 3–4 |
 | [#49](https://github.com/deelmarkt-org/app/issues/49) | `[R]` 30-day soft-delete grace period | reso | — | 5–8 |
-| [#50](https://github.com/deelmarkt-org/app/issues/50) | ~~`[P]` Wire address form navigation in Settings~~ | pizmam | — | ✅ PR #feature/pizmam-deferred-nav-wiring |
-| [#51](https://github.com/deelmarkt-org/app/issues/51) | ~~`[P]` Wire sell screen navigation from empty listings~~ | pizmam | P-24 | ✅ PR #feature/pizmam-deferred-nav-wiring |
-| [#52](https://github.com/deelmarkt-org/app/issues/52) | ~~`[P]` Wire listing detail navigation from profile~~ | pizmam | B-51 | ✅ PR #feature/pizmam-deferred-nav-wiring |
-| [#53](https://github.com/deelmarkt-org/app/issues/53) | ~~`[P]` Wire avatar picker navigation~~ | pizmam | — | ✅ PR #feature/pizmam-deferred-nav-wiring |
+| [#50](https://github.com/deelmarkt-org/app/issues/50) | ~~`[P]` Wire address form navigation in Settings~~ | pizmam | — | ✅ PR #149 |
+| [#51](https://github.com/deelmarkt-org/app/issues/51) | ~~`[P]` Wire sell screen navigation from empty listings~~ | pizmam | P-24 | ✅ PR #149 |
+| [#52](https://github.com/deelmarkt-org/app/issues/52) | ~~`[P]` Wire listing detail navigation from profile~~ | pizmam | B-51 | ✅ PR #149 |
+| [#53](https://github.com/deelmarkt-org/app/issues/53) | ~~`[P]` Wire avatar picker navigation~~ | pizmam | — | ✅ PR #149 |
 
 ---
 

--- a/lib/core/services/repository_providers.dart
+++ b/lib/core/services/repository_providers.dart
@@ -26,6 +26,9 @@ import 'package:deelmarkt/features/profile/domain/repositories/review_repository
 import 'package:deelmarkt/features/profile/domain/repositories/sanction_repository.dart';
 import 'package:deelmarkt/features/profile/domain/repositories/settings_repository.dart';
 import 'package:deelmarkt/features/profile/domain/repositories/user_repository.dart';
+import 'package:deelmarkt/features/profile/data/mock/mock_avatar_upload_service.dart';
+import 'package:deelmarkt/features/profile/data/services/supabase_avatar_upload_service.dart';
+import 'package:deelmarkt/features/profile/domain/services/avatar_upload_service.dart';
 import 'package:deelmarkt/features/admin/data/mock/mock_admin_repository.dart';
 import 'package:deelmarkt/features/admin/data/supabase/supabase_admin_repository.dart';
 import 'package:deelmarkt/features/admin/domain/repositories/admin_repository.dart';
@@ -139,6 +142,16 @@ final sanctionRepositoryProvider = Provider<SanctionRepository>((ref) {
   final useMock = ref.watch(useMockDataProvider);
   if (useMock) return MockSanctionRepository();
   return SupabaseSanctionRepository(ref.watch(supabaseClientProvider));
+});
+
+/// Avatar upload service — mock or Supabase based on [useMockDataProvider].
+///
+/// Uploads avatar images to `avatars/<user_id>/<timestamp>.<ext>` in Storage.
+/// Mock mode returns a fake Cloudinary URL for development/testing.
+final avatarUploadServiceProvider = Provider<AvatarUploadService>((ref) {
+  final useMock = ref.watch(useMockDataProvider);
+  if (useMock) return MockAvatarUploadService();
+  return SupabaseAvatarUploadService(ref.watch(supabaseClientProvider));
 });
 
 /// DSA report repository — mock or Supabase based on [useMockDataProvider].

--- a/lib/features/profile/data/mock/mock_avatar_upload_service.dart
+++ b/lib/features/profile/data/mock/mock_avatar_upload_service.dart
@@ -1,0 +1,16 @@
+import 'package:deelmarkt/features/profile/domain/services/avatar_upload_service.dart';
+
+/// Mock avatar upload service for development and testing.
+///
+/// Returns a fake Cloudinary-style URL after a short delay.
+class MockAvatarUploadService implements AvatarUploadService {
+  @override
+  Future<String> upload({
+    required String userId,
+    required String filePath,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    return 'https://res.cloudinary.com/demo/image/upload/avatars/$userId/$timestamp.webp';
+  }
+}

--- a/lib/features/profile/data/services/supabase_avatar_upload_service.dart
+++ b/lib/features/profile/data/services/supabase_avatar_upload_service.dart
@@ -11,6 +11,16 @@ import 'package:deelmarkt/features/profile/domain/services/avatar_upload_service
 /// Path pattern: `avatars/<userId>/<timestamp>.<ext>`
 /// RLS enforces folder-level isolation per user.
 ///
+/// TODO(#148): `avatars` bucket + RLS must be provisioned by reso before
+/// this service is used in production. Until then, [MockAvatarUploadService]
+/// is used via the `useMockDataProvider` gate in [avatarUploadServiceProvider].
+///
+/// TODO(#148): Decide public vs private bucket before provisioning.
+/// `getPublicUrl()` returns a URL that 403s if the bucket is private (GDPR
+/// concern for user PII). Options: public bucket, signed URL with TTL, or
+/// Cloudinary pipeline like listings-images. Agree with reso before creating
+/// the bucket migration.
+///
 /// Reference: docs/screens/07-profile/01-own-profile.md
 class SupabaseAvatarUploadService implements AvatarUploadService {
   SupabaseAvatarUploadService(this._client);
@@ -20,7 +30,8 @@ class SupabaseAvatarUploadService implements AvatarUploadService {
   static const _bucket = 'avatars';
 
   /// Maximum file size: 15 MiB (matches Storage bucket limit).
-  static const _maxFileSizeBytes = 15 * 1024 * 1024;
+  // ignore: avoid_field_initializers_in_const_classes
+  static const maxFileSizeBytes = 15 * 1024 * 1024;
 
   /// Allowed image file extensions.
   static const _allowedExtensions = {'jpg', 'jpeg', 'png', 'webp', 'heic'};
@@ -39,7 +50,7 @@ class SupabaseAvatarUploadService implements AvatarUploadService {
 
     final file = File(filePath);
 
-    _validateFile(file);
+    await _validateFile(file);
 
     final extension = p.extension(filePath).replaceFirst('.', '').toLowerCase();
     final storagePath =
@@ -56,7 +67,7 @@ class SupabaseAvatarUploadService implements AvatarUploadService {
     return _client.storage.from(_bucket).getPublicUrl(storagePath);
   }
 
-  void _validateFile(File file) {
+  Future<void> _validateFile(File file) async {
     final extension =
         p.extension(file.path).replaceFirst('.', '').toLowerCase();
 
@@ -67,11 +78,11 @@ class SupabaseAvatarUploadService implements AvatarUploadService {
       );
     }
 
-    final size = file.lengthSync();
-    if (size > _maxFileSizeBytes) {
+    final size = await file.length();
+    if (size > maxFileSizeBytes) {
       throw FormatException(
         'Image too large: ${(size / 1024 / 1024).toStringAsFixed(1)} MB. '
-        'Maximum: ${_maxFileSizeBytes ~/ 1024 ~/ 1024} MB',
+        'Maximum: ${maxFileSizeBytes ~/ 1024 ~/ 1024} MB',
       );
     }
   }

--- a/lib/features/profile/data/services/supabase_avatar_upload_service.dart
+++ b/lib/features/profile/data/services/supabase_avatar_upload_service.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:path/path.dart' as p;
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -29,6 +30,13 @@ class SupabaseAvatarUploadService implements AvatarUploadService {
     required String userId,
     required String filePath,
   }) async {
+    if (kIsWeb) {
+      throw UnsupportedError(
+        'SupabaseAvatarUploadService does not support web. '
+        'Use a web-specific implementation with Uint8List.',
+      );
+    }
+
     final file = File(filePath);
 
     _validateFile(file);

--- a/lib/features/profile/data/services/supabase_avatar_upload_service.dart
+++ b/lib/features/profile/data/services/supabase_avatar_upload_service.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:deelmarkt/features/profile/domain/services/avatar_upload_service.dart';
+
+/// Uploads avatar images to the `avatars` Supabase Storage bucket.
+///
+/// Path pattern: `avatars/<userId>/<timestamp>.<ext>`
+/// RLS enforces folder-level isolation per user.
+///
+/// Reference: docs/screens/07-profile/01-own-profile.md
+class SupabaseAvatarUploadService implements AvatarUploadService {
+  SupabaseAvatarUploadService(this._client);
+
+  final SupabaseClient _client;
+
+  static const _bucket = 'avatars';
+
+  /// Maximum file size: 15 MiB (matches Storage bucket limit).
+  static const _maxFileSizeBytes = 15 * 1024 * 1024;
+
+  /// Allowed image file extensions.
+  static const _allowedExtensions = {'jpg', 'jpeg', 'png', 'webp', 'heic'};
+
+  @override
+  Future<String> upload({
+    required String userId,
+    required String filePath,
+  }) async {
+    final file = File(filePath);
+
+    _validateFile(file);
+
+    final extension = p.extension(filePath).replaceFirst('.', '').toLowerCase();
+    final storagePath =
+        '$userId/${DateTime.now().millisecondsSinceEpoch}.$extension';
+
+    await _client.storage
+        .from(_bucket)
+        .upload(
+          storagePath,
+          file,
+          fileOptions: const FileOptions(upsert: true),
+        );
+
+    return _client.storage.from(_bucket).getPublicUrl(storagePath);
+  }
+
+  void _validateFile(File file) {
+    final extension =
+        p.extension(file.path).replaceFirst('.', '').toLowerCase();
+
+    if (!_allowedExtensions.contains(extension)) {
+      throw FormatException(
+        'Unsupported image format: $extension. '
+        'Allowed: ${_allowedExtensions.join(', ')}',
+      );
+    }
+
+    final size = file.lengthSync();
+    if (size > _maxFileSizeBytes) {
+      throw FormatException(
+        'Image too large: ${(size / 1024 / 1024).toStringAsFixed(1)} MB. '
+        'Maximum: ${_maxFileSizeBytes ~/ 1024 ~/ 1024} MB',
+      );
+    }
+  }
+}

--- a/lib/features/profile/domain/services/avatar_upload_service.dart
+++ b/lib/features/profile/domain/services/avatar_upload_service.dart
@@ -1,0 +1,9 @@
+/// Avatar upload service interface — domain layer.
+///
+/// Reference: docs/screens/07-profile/01-own-profile.md
+abstract class AvatarUploadService {
+  /// Uploads an avatar image and returns the public URL.
+  ///
+  /// Throws on validation failure (wrong format, too large) or upload error.
+  Future<String> upload({required String userId, required String filePath});
+}

--- a/lib/features/profile/presentation/screens/settings_screen.dart
+++ b/lib/features/profile/presentation/screens/settings_screen.dart
@@ -11,6 +11,7 @@ import 'package:deelmarkt/core/domain/entities/dutch_address.dart';
 import 'package:deelmarkt/features/profile/presentation/widgets/address_form_modal.dart';
 import 'package:deelmarkt/features/profile/presentation/widgets/app_info_section.dart';
 import 'package:deelmarkt/features/profile/presentation/widgets/delete_account_dialog.dart';
+import 'package:deelmarkt/features/profile/presentation/widgets/delete_address_dialog.dart';
 import 'package:deelmarkt/features/profile/presentation/widgets/notifications_section.dart';
 import 'package:deelmarkt/features/profile/presentation/widgets/privacy_section.dart';
 import 'package:deelmarkt/features/profile/presentation/viewmodels/profile_viewmodel.dart';
@@ -108,10 +109,17 @@ class SettingsScreen extends ConsumerWidget {
             onEdit:
                 (address) =>
                     _saveAddressFromModal(context, ref, existing: address),
-            onDelete:
-                (address) => ref
+            onDelete: (address) async {
+              final confirmed = await DeleteAddressDialog.show(
+                context,
+                address,
+              );
+              if (confirmed == true && context.mounted) {
+                await ref
                     .read(settingsNotifierProvider.notifier)
-                    .deleteAddress(address),
+                    .deleteAddress(address);
+              }
+            },
           ),
     );
   }

--- a/lib/features/profile/presentation/viewmodels/profile_viewmodel.dart
+++ b/lib/features/profile/presentation/viewmodels/profile_viewmodel.dart
@@ -15,21 +15,25 @@ class ProfileState {
     this.user = const AsyncValue.loading(),
     this.listings = const AsyncValue.loading(),
     this.reviews = const AsyncValue.loading(),
+    this.isUploadingAvatar = false,
   });
 
   final AsyncValue<UserEntity?> user;
   final AsyncValue<List<ListingEntity>> listings;
   final AsyncValue<List<ReviewEntity>> reviews;
+  final bool isUploadingAvatar;
 
   ProfileState copyWith({
     AsyncValue<UserEntity?>? user,
     AsyncValue<List<ListingEntity>>? listings,
     AsyncValue<List<ReviewEntity>>? reviews,
+    bool? isUploadingAvatar,
   }) {
     return ProfileState(
       user: user ?? this.user,
       listings: listings ?? this.listings,
       reviews: reviews ?? this.reviews,
+      isUploadingAvatar: isUploadingAvatar ?? this.isUploadingAvatar,
     );
   }
 }
@@ -73,5 +77,46 @@ class ProfileNotifier extends _$ProfileNotifier {
       listings: results[0] as AsyncValue<List<ListingEntity>>,
       reviews: results[1] as AsyncValue<List<ReviewEntity>>,
     );
+  }
+
+  /// Uploads a new avatar image and updates the user profile.
+  ///
+  /// Sets [isUploadingAvatar] during the upload. On failure,
+  /// reverts [user.avatarUrl] to the previous value.
+  Future<void> uploadAvatar(String imagePath) async {
+    final previousUrl = state.user.valueOrNull?.avatarUrl;
+    state = state.copyWith(isUploadingAvatar: true);
+
+    try {
+      final userId = state.user.valueOrNull?.id;
+      if (userId == null) {
+        throw StateError('Cannot upload avatar: user not loaded');
+      }
+
+      final service = ref.read(avatarUploadServiceProvider);
+      final publicUrl = await service.upload(
+        userId: userId,
+        filePath: imagePath,
+      );
+
+      final userRepo = ref.read(userRepositoryProvider);
+      final updated = await userRepo.updateProfile(avatarUrl: publicUrl);
+
+      state = state.copyWith(
+        user: AsyncValue.data(updated),
+        isUploadingAvatar: false,
+      );
+    } on Exception {
+      final currentUser = state.user.valueOrNull;
+      if (currentUser != null) {
+        state = state.copyWith(
+          user: AsyncValue.data(currentUser.copyWith(avatarUrl: previousUrl)),
+          isUploadingAvatar: false,
+        );
+      } else {
+        state = state.copyWith(isUploadingAvatar: false);
+      }
+      rethrow;
+    }
   }
 }

--- a/lib/features/profile/presentation/viewmodels/profile_viewmodel.dart
+++ b/lib/features/profile/presentation/viewmodels/profile_viewmodel.dart
@@ -106,7 +106,7 @@ class ProfileNotifier extends _$ProfileNotifier {
         user: AsyncValue.data(updated),
         isUploadingAvatar: false,
       );
-    } on Exception {
+    } on Object catch (_) {
       final currentUser = state.user.valueOrNull;
       if (currentUser != null) {
         state = state.copyWith(

--- a/lib/features/profile/presentation/widgets/addresses_section.dart
+++ b/lib/features/profile/presentation/widgets/addresses_section.dart
@@ -78,10 +78,17 @@ class _AddressTile extends StatelessWidget {
               onPressed: onEdit,
               tooltip: 'action.edit'.tr(),
             ),
-            IconButton(
-              icon: Icon(PhosphorIcons.trash(), color: theme.colorScheme.error),
-              onPressed: onDelete,
-              tooltip: 'action.delete'.tr(),
+            Semantics(
+              button: true,
+              label: '${'action.delete'.tr()} ${address.formatted}',
+              child: IconButton(
+                icon: Icon(
+                  PhosphorIcons.trash(),
+                  color: theme.colorScheme.error,
+                ),
+                onPressed: onDelete,
+                tooltip: 'action.delete'.tr(),
+              ),
             ),
           ],
         ),

--- a/lib/features/profile/presentation/widgets/delete_address_dialog.dart
+++ b/lib/features/profile/presentation/widgets/delete_address_dialog.dart
@@ -1,0 +1,66 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+
+import 'package:deelmarkt/core/design_system/spacing.dart';
+import 'package:deelmarkt/core/domain/entities/dutch_address.dart';
+import 'package:deelmarkt/widgets/buttons/deel_button.dart';
+
+/// Destructive confirmation dialog for address deletion.
+///
+/// Returns `true` when the user confirms, `null` when cancelled.
+/// Uses [barrierDismissible: false] so accidental taps outside the dialog
+/// cannot trigger a deletion (OWASP user-consent principle).
+///
+/// Reference: docs/screens/07-profile/03-settings.md — addresses section
+class DeleteAddressDialog extends StatelessWidget {
+  const DeleteAddressDialog({required this.address, super.key});
+
+  final DutchAddress address;
+
+  /// Shows the dialog and returns [true] on confirm, [null] on cancel.
+  static Future<bool?> show(BuildContext context, DutchAddress address) {
+    return showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => DeleteAddressDialog(address: address),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return AlertDialog(
+      title: Text('settings.deleteAddressTitle'.tr()),
+      content: Text(address.formatted, style: theme.textTheme.bodyMedium),
+      actions: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: Spacing.s2),
+          child: Semantics(
+            button: true,
+            child: DeelButton(
+              label: 'action.cancel'.tr(),
+              onPressed: () => Navigator.of(context).pop(),
+              variant: DeelButtonVariant.ghost,
+              size: DeelButtonSize.medium,
+              fullWidth: false,
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.only(bottom: Spacing.s2),
+          child: Semantics(
+            button: true,
+            child: DeelButton(
+              label: 'action.delete'.tr(),
+              onPressed: () => Navigator.of(context).pop(true),
+              variant: DeelButtonVariant.destructive,
+              size: DeelButtonSize.medium,
+              fullWidth: false,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/profile/presentation/widgets/profile_header.dart
+++ b/lib/features/profile/presentation/widgets/profile_header.dart
@@ -58,7 +58,11 @@ class ProfileHeader extends ConsumerWidget {
     if (source == null || !context.mounted) return;
 
     final picker = ImagePicker();
-    final image = await picker.pickImage(source: source);
+    // requestFullMetadata: false strips EXIF (GPS location) per GDPR.
+    final image = await picker.pickImage(
+      source: source,
+      requestFullMetadata: false,
+    );
 
     if (image != null && context.mounted) {
       try {

--- a/lib/features/profile/presentation/widgets/profile_header.dart
+++ b/lib/features/profile/presentation/widgets/profile_header.dart
@@ -65,7 +65,7 @@ class ProfileHeader extends ConsumerWidget {
         await ref
             .read(profileNotifierProvider.notifier)
             .uploadAvatar(image.path);
-      } on Exception {
+      } on Object catch (_) {
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(content: Text('profile.avatarUploadFailed'.tr())),

--- a/lib/features/profile/presentation/widgets/profile_header.dart
+++ b/lib/features/profile/presentation/widgets/profile_header.dart
@@ -1,22 +1,26 @@
-import 'dart:developer' as developer;
-
 import 'package:easy_localization/easy_localization.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 import 'package:deelmarkt/core/design_system/spacing.dart';
 import 'package:deelmarkt/features/profile/domain/entities/user_entity.dart';
+import 'package:deelmarkt/features/profile/presentation/viewmodels/profile_viewmodel.dart';
 import 'package:deelmarkt/widgets/badges/deel_avatar.dart';
 
 /// Profile header with avatar, display name, and member-since date.
-class ProfileHeader extends StatelessWidget {
+///
+/// Tapping the avatar edit overlay opens an image picker and uploads
+/// the selected image via [ProfileNotifier.uploadAvatar].
+///
+/// Reference: docs/screens/07-profile/01-own-profile.md
+class ProfileHeader extends ConsumerWidget {
   const ProfileHeader({required this.user, super.key});
 
   final UserEntity user;
 
-  Future<void> _showImagePicker(BuildContext context) async {
+  Future<void> _showImagePicker(BuildContext context, WidgetRef ref) async {
     final source = await showModalBottomSheet<ImageSource>(
       context: context,
       builder: (context) {
@@ -57,31 +61,48 @@ class ProfileHeader extends StatelessWidget {
     final image = await picker.pickImage(source: source);
 
     if (image != null && context.mounted) {
-      if (kDebugMode) {
-        developer.log(
-          'Avatar image selected: ${image.path}',
-          name: 'ProfileHeader',
-        );
+      try {
+        await ref
+            .read(profileNotifierProvider.notifier)
+            .uploadAvatar(image.path);
+      } on Exception {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('profile.avatarUploadFailed'.tr())),
+          );
+        }
       }
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('profile.photoSelected'.tr())));
     }
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final locale = context.locale.languageCode;
     final memberSince = DateFormat.yMMM(locale).format(user.createdAt);
+    final profileState = ref.watch(profileNotifierProvider);
 
     return Column(
       children: [
-        DeelAvatar(
-          displayName: user.displayName,
-          imageUrl: user.avatarUrl,
-          size: DeelAvatarSize.large,
-          showEditOverlay: true,
-          onEditTap: () => _showImagePicker(context),
+        Stack(
+          alignment: Alignment.center,
+          children: [
+            DeelAvatar(
+              displayName: user.displayName,
+              imageUrl: user.avatarUrl,
+              size: DeelAvatarSize.large,
+              showEditOverlay: true,
+              onEditTap: () => _showImagePicker(context, ref),
+            ),
+            if (profileState.isUploadingAvatar)
+              Semantics(
+                label: 'profile.avatarUploading'.tr(),
+                child: const SizedBox(
+                  width: 80,
+                  height: 80,
+                  child: CircularProgressIndicator(strokeWidth: 3),
+                ),
+              ),
+          ],
         ),
         const SizedBox(height: Spacing.s3),
         Text(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -734,7 +734,7 @@ packages:
     source: hosted
     version: "0.2.2+1"
   image_picker_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: image_picker_platform_interface
       sha256: "567e056716333a1647c64bb6bd873cff7622233a5c3f694be28a583d4715690c"
@@ -897,10 +897,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1030,7 +1030,7 @@ packages:
     source: hosted
     version: "3.1.6"
   plugin_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -958,7 +958,7 @@ packages:
     source: hosted
     version: "3.2.1"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -94,6 +94,10 @@ dev_dependencies:
   envied_generator: ^1.1.1
   mocktail: ^1.0.4
 
+  # Platform interface packages — required for ImagePickerPlatform test mocking
+  image_picker_platform_interface: any
+  plugin_platform_interface: any
+
 flutter:
   uses-material-design: true
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,6 +75,9 @@ dependencies:
   # Image picker — camera + gallery for avatar upload (P-53)
   image_picker: ^1.1.2
 
+  # File path utilities — used by SupabaseAvatarUploadService for extension parsing
+  path: ^1.9.0
+
 
 dev_dependencies:
   flutter_test:

--- a/test/features/home/presentation/widgets/seller_home_empty_view_test.dart
+++ b/test/features/home/presentation/widgets/seller_home_empty_view_test.dart
@@ -84,5 +84,29 @@ void main() {
 
       expect(find.byType(CustomScrollView), findsOneWidget);
     });
+
+    // Task #51: sell-from-empty navigation wiring
+    testWidgets('#51 — DeelButton label is home.seller.startSelling', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
+
+      final button = tester.widget<DeelButton>(find.byType(DeelButton));
+      // tr() returns key path in test env (translations not loaded).
+      expect(button.label, 'home.seller.startSelling');
+
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('#51 — DeelButton onPressed is not null', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
+
+      final button = tester.widget<DeelButton>(find.byType(DeelButton));
+      expect(button.onPressed, isNotNull);
+
+      await tester.pumpAndSettle();
+    });
   });
 }

--- a/test/features/listing_detail/presentation/listing_detail_screen_test.dart
+++ b/test/features/listing_detail/presentation/listing_detail_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:deelmarkt/core/services/repository_providers.dart';
 import 'package:deelmarkt/features/listing_detail/presentation/listing_detail_screen.dart';
 import 'package:deelmarkt/features/listing_detail/presentation/widgets/detail_action_bar.dart';
 import 'package:deelmarkt/features/listing_detail/presentation/widgets/detail_loading_view.dart';
+import 'package:deelmarkt/features/listing_detail/presentation/widgets/detail_seller_card.dart';
 import 'package:deelmarkt/features/listing_detail/presentation/widgets/sold_overlay.dart';
 import 'package:deelmarkt/widgets/feedback/error_state.dart';
 
@@ -60,6 +61,22 @@ void main() {
 
       expect(find.byType(SoldOverlay), findsNothing);
       expect(find.byType(DetailActionBar), findsOneWidget);
+    });
+
+    testWidgets('#52 — seller card is rendered and onViewProfile is wired', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+
+      // DetailSellerCard may be off-screen in a small viewport — use
+      // skipOffstage: false to find it anywhere in the widget tree.
+      final cardFinder = find.byType(DetailSellerCard, skipOffstage: false);
+      expect(cardFinder, findsOneWidget);
+
+      // The seller card has a wired onViewProfile (InkWell is tappable).
+      final card = tester.widget<DetailSellerCard>(cardFinder);
+      expect(card.onViewProfile, isNotNull);
     });
 
     testWidgets('expanded width renders 2-column layout', (tester) async {

--- a/test/features/profile/data/services/avatar_upload_service_test.dart
+++ b/test/features/profile/data/services/avatar_upload_service_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:deelmarkt/features/profile/data/mock/mock_avatar_upload_service.dart';
+import 'package:deelmarkt/features/sell/data/services/image_picker_service.dart';
+
+void main() {
+  group('MockAvatarUploadService', () {
+    late MockAvatarUploadService service;
+
+    setUp(() {
+      service = MockAvatarUploadService();
+    });
+
+    test('upload returns a non-empty URL', () async {
+      final url = await service.upload(
+        userId: 'user-001',
+        filePath: '/tmp/avatar.jpg',
+      );
+
+      expect(url, isNotEmpty);
+      expect(url, startsWith('https://'));
+    });
+
+    test('upload includes userId in the returned URL', () async {
+      const userId = 'user-42';
+      final url = await service.upload(
+        userId: userId,
+        filePath: '/tmp/photo.png',
+      );
+
+      expect(url, contains(userId));
+    });
+
+    test('upload returns different URLs for subsequent calls', () async {
+      final url1 = await service.upload(
+        userId: 'user-001',
+        filePath: '/tmp/a.jpg',
+      );
+      // Small delay to ensure different timestamps.
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      final url2 = await service.upload(
+        userId: 'user-001',
+        filePath: '/tmp/b.jpg',
+      );
+
+      expect(url1, isNot(equals(url2)));
+    });
+
+    test(
+      'upload completes within a reasonable time (mock delay ~300ms)',
+      () async {
+        final stopwatch = Stopwatch()..start();
+        await service.upload(userId: 'user-001', filePath: '/tmp/avatar.jpg');
+        stopwatch.stop();
+
+        // Mock has 300ms delay — should complete within 1s.
+        expect(stopwatch.elapsedMilliseconds, lessThan(1000));
+      },
+    );
+  });
+
+  group(
+    'ImagePickerService constants (used by SupabaseAvatarUploadService)',
+    () {
+      test('allowedExtensions includes common image formats', () {
+        expect(ImagePickerService.allowedExtensions, contains('jpg'));
+        expect(ImagePickerService.allowedExtensions, contains('jpeg'));
+        expect(ImagePickerService.allowedExtensions, contains('png'));
+        expect(ImagePickerService.allowedExtensions, contains('webp'));
+        expect(ImagePickerService.allowedExtensions, contains('heic'));
+      });
+
+      test('maxFileSizeBytes is 15 MB', () {
+        expect(ImagePickerService.maxFileSizeBytes, equals(15 * 1024 * 1024));
+      });
+    },
+  );
+}

--- a/test/features/profile/data/services/supabase_avatar_upload_service_test.dart
+++ b/test/features/profile/data/services/supabase_avatar_upload_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -5,28 +7,176 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:deelmarkt/features/profile/data/services/supabase_avatar_upload_service.dart';
 import 'package:deelmarkt/features/profile/domain/services/avatar_upload_service.dart';
 
-class MockSupabaseClient extends Mock implements SupabaseClient {}
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+class _MockSupabaseClient extends Mock implements SupabaseClient {}
+
+class _MockSupabaseStorageClient extends Mock
+    implements SupabaseStorageClient {}
+
+class _MockStorageFileApi extends Mock implements StorageFileApi {}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Creates a temporary file with the given [extension] and [sizeBytes] content.
+/// Auto-deleted via [addTearDown].
+Future<File> _makeTempFile({
+  required String extension,
+  int sizeBytes = 512,
+}) async {
+  final dir = await Directory.systemTemp.createTemp('avatar_svc_test');
+  addTearDown(() async {
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  });
+  final file = File('${dir.path}/avatar.$extension');
+  await file.writeAsBytes(List<int>.filled(sizeBytes, 0));
+  return file;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(File('fallback.jpg'));
+    registerFallbackValue(const FileOptions());
+  });
+
   group('SupabaseAvatarUploadService', () {
     test('implements AvatarUploadService interface', () {
-      final client = MockSupabaseClient();
+      final client = _MockSupabaseClient();
       final AvatarUploadService service = SupabaseAvatarUploadService(client);
 
       expect(service, isA<AvatarUploadService>());
     });
 
     test('rejects unsupported file extensions', () {
-      final client = MockSupabaseClient();
+      final client = _MockSupabaseClient();
       final service = SupabaseAvatarUploadService(client);
 
-      // _validateFile is called via upload — we can test via a non-existent
-      // path with a bad extension; File(path).lengthSync() will throw before
-      // the extension check in a real run, but _validateFile is called first.
-      // Use a fake path with an unsupported extension.
+      // Extension check happens before file.length() — no real file needed.
       expect(
         () => service.upload(userId: 'user-1', filePath: '/tmp/avatar.bmp'),
         throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('uploads file to storage and returns public URL', () async {
+      final client = _MockSupabaseClient();
+      final storage = _MockSupabaseStorageClient();
+      final fileApi = _MockStorageFileApi();
+      final service = SupabaseAvatarUploadService(client);
+
+      const publicUrl =
+          'https://supabase.co/storage/v1/object/public/avatars/u1/123.jpg';
+
+      when(() => client.storage).thenReturn(storage);
+      when(() => storage.from(any())).thenReturn(fileApi);
+      when(
+        () => fileApi.upload(
+          any(),
+          any(),
+          fileOptions: any(named: 'fileOptions'),
+        ),
+      ).thenAnswer((_) async => '');
+      when(() => fileApi.getPublicUrl(any())).thenReturn(publicUrl);
+
+      final file = await _makeTempFile(extension: 'jpg');
+      final result = await service.upload(userId: 'u1', filePath: file.path);
+
+      expect(result, equals(publicUrl));
+      verify(() => storage.from('avatars')).called(2);
+      verify(
+        () => fileApi.upload(
+          any(),
+          any(),
+          fileOptions: any(named: 'fileOptions'),
+        ),
+      ).called(1);
+      verify(() => fileApi.getPublicUrl(any())).called(1);
+    });
+
+    test(
+      'storage path includes userId and timestamp with correct extension',
+      () async {
+        final client = _MockSupabaseClient();
+        final storage = _MockSupabaseStorageClient();
+        final fileApi = _MockStorageFileApi();
+        final service = SupabaseAvatarUploadService(client);
+
+        when(() => client.storage).thenReturn(storage);
+        when(() => storage.from(any())).thenReturn(fileApi);
+        when(
+          () => fileApi.upload(
+            any(),
+            any(),
+            fileOptions: any(named: 'fileOptions'),
+          ),
+        ).thenAnswer((_) async => '');
+        when(
+          () => fileApi.getPublicUrl(any()),
+        ).thenReturn('https://example.com');
+
+        final file = await _makeTempFile(extension: 'png');
+        await service.upload(userId: 'user-42', filePath: file.path);
+
+        final captured =
+            verify(
+              () => fileApi.upload(
+                captureAny(),
+                any(),
+                fileOptions: any(named: 'fileOptions'),
+              ),
+            ).captured;
+
+        final path = captured.first as String;
+        expect(path, startsWith('user-42/'));
+        expect(path, endsWith('.png'));
+      },
+    );
+
+    test('upsert FileOptions is passed to storage upload', () async {
+      final client = _MockSupabaseClient();
+      final storage = _MockSupabaseStorageClient();
+      final fileApi = _MockStorageFileApi();
+      final service = SupabaseAvatarUploadService(client);
+
+      when(() => client.storage).thenReturn(storage);
+      when(() => storage.from(any())).thenReturn(fileApi);
+      when(
+        () => fileApi.upload(
+          any(),
+          any(),
+          fileOptions: any(named: 'fileOptions'),
+        ),
+      ).thenAnswer((_) async => '');
+      when(() => fileApi.getPublicUrl(any())).thenReturn('https://example.com');
+
+      final file = await _makeTempFile(extension: 'webp');
+      await service.upload(userId: 'u1', filePath: file.path);
+
+      final captured =
+          verify(
+            () => fileApi.upload(
+              any(),
+              any(),
+              fileOptions: captureAny(named: 'fileOptions'),
+            ),
+          ).captured;
+
+      final opts = captured.first as FileOptions;
+      expect(opts.upsert, isTrue);
+    });
+
+    test('maxFileSizeBytes is 15 MiB', () {
+      expect(
+        SupabaseAvatarUploadService.maxFileSizeBytes,
+        equals(15 * 1024 * 1024),
       );
     });
   });

--- a/test/features/profile/data/services/supabase_avatar_upload_service_test.dart
+++ b/test/features/profile/data/services/supabase_avatar_upload_service_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:deelmarkt/features/profile/data/services/supabase_avatar_upload_service.dart';
+import 'package:deelmarkt/features/profile/domain/services/avatar_upload_service.dart';
+
+class MockSupabaseClient extends Mock implements SupabaseClient {}
+
+void main() {
+  group('SupabaseAvatarUploadService', () {
+    test('implements AvatarUploadService interface', () {
+      final client = MockSupabaseClient();
+      final AvatarUploadService service = SupabaseAvatarUploadService(client);
+
+      expect(service, isA<AvatarUploadService>());
+    });
+
+    test('rejects unsupported file extensions', () {
+      final client = MockSupabaseClient();
+      final service = SupabaseAvatarUploadService(client);
+
+      // _validateFile is called via upload — we can test via a non-existent
+      // path with a bad extension; File(path).lengthSync() will throw before
+      // the extension check in a real run, but _validateFile is called first.
+      // Use a fake path with an unsupported extension.
+      expect(
+        () => service.upload(userId: 'user-1', filePath: '/tmp/avatar.bmp'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+}

--- a/test/features/profile/domain/services/avatar_upload_service_test.dart
+++ b/test/features/profile/domain/services/avatar_upload_service_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:deelmarkt/features/profile/data/mock/mock_avatar_upload_service.dart';
+import 'package:deelmarkt/features/profile/domain/services/avatar_upload_service.dart';
+
+void main() {
+  group('AvatarUploadService interface', () {
+    test('MockAvatarUploadService implements AvatarUploadService', () {
+      // Verify the interface contract: any implementation must provide upload().
+      final AvatarUploadService service = MockAvatarUploadService();
+      expect(service, isA<AvatarUploadService>());
+    });
+  });
+}

--- a/test/features/profile/presentation/screens/settings_screen_test.dart
+++ b/test/features/profile/presentation/screens/settings_screen_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:deelmarkt/features/profile/presentation/widgets/account_section.dart';
 import 'package:deelmarkt/features/profile/presentation/widgets/addresses_section.dart';
 import 'package:deelmarkt/features/profile/presentation/widgets/app_info_section.dart';
+import 'package:deelmarkt/features/profile/presentation/widgets/delete_address_dialog.dart';
 import 'package:deelmarkt/features/profile/presentation/widgets/notifications_section.dart';
 import 'package:deelmarkt/features/profile/presentation/widgets/privacy_section.dart';
 
@@ -210,6 +211,47 @@ void main() {
       await pumpSettingsScreen(tester);
 
       expect(find.byType(AppInfoSection), findsOneWidget);
+    });
+
+    // Task #50: delete confirmation dialog tests
+    testWidgets('tapping delete opens DeleteAddressDialog', (tester) async {
+      await pumpSettingsScreen(tester);
+
+      await tester.tap(find.byTooltip('action.delete'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(DeleteAddressDialog), findsOneWidget);
+      expect(find.text('settings.deleteAddressTitle'), findsOneWidget);
+    });
+
+    testWidgets('confirming delete dismisses dialog and calls repo', (
+      tester,
+    ) async {
+      await pumpSettingsScreen(tester);
+
+      await tester.tap(find.byTooltip('action.delete'));
+      await tester.pumpAndSettle();
+
+      // Confirm deletion.
+      await tester.tap(find.text('action.delete'));
+      await tester.pumpAndSettle();
+
+      // Dialog should be dismissed after confirmation.
+      expect(find.byType(DeleteAddressDialog), findsNothing);
+    });
+
+    testWidgets('cancelling delete keeps address in list', (tester) async {
+      await pumpSettingsScreen(tester);
+
+      await tester.tap(find.byTooltip('action.delete'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('action.cancel'));
+      await tester.pumpAndSettle();
+
+      // Dialog dismissed, address still present.
+      expect(find.byType(DeleteAddressDialog), findsNothing);
+      expect(find.text('Damstraat 42, 1012 AB Amsterdam'), findsOneWidget);
     });
   });
 }

--- a/test/features/profile/presentation/viewmodels/profile_viewmodel_test.dart
+++ b/test/features/profile/presentation/viewmodels/profile_viewmodel_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:deelmarkt/core/services/repository_providers.dart';
+import 'package:deelmarkt/features/profile/data/mock/mock_avatar_upload_service.dart';
 import 'package:deelmarkt/features/profile/presentation/viewmodels/profile_viewmodel.dart';
 
 /// Creates a container with mock data, subscribes to keep the provider alive,
@@ -96,6 +97,80 @@ void main() {
 
       final repo = container.read(reviewRepositoryProvider);
       expect(repo, isNotNull);
+    });
+  });
+
+  group('ProfileNotifier.uploadAvatar (#53)', () {
+    test(
+      'sets isUploadingAvatar true during upload then false on success',
+      () async {
+        final container = await _loadedContainer();
+        addTearDown(container.dispose);
+
+        var seenUploading = false;
+        container.listen(profileNotifierProvider, (_, state) {
+          if (state.isUploadingAvatar) seenUploading = true;
+        });
+
+        await container
+            .read(profileNotifierProvider.notifier)
+            .uploadAvatar('/tmp/avatar.jpg');
+
+        expect(seenUploading, isTrue);
+        expect(
+          container.read(profileNotifierProvider).isUploadingAvatar,
+          isFalse,
+        );
+      },
+    );
+
+    test('uploadAvatar success updates user.avatarUrl in state', () async {
+      final container = await _loadedContainer();
+      addTearDown(container.dispose);
+
+      final previousUrl =
+          container.read(profileNotifierProvider).user.requireValue?.avatarUrl;
+
+      await container
+          .read(profileNotifierProvider.notifier)
+          .uploadAvatar('/tmp/new_avatar.png');
+
+      final updatedUrl =
+          container.read(profileNotifierProvider).user.requireValue?.avatarUrl;
+
+      // MockAvatarUploadService returns a fake Cloudinary URL containing
+      // the userId; the mock user repo echo-returns it via updateProfile().
+      expect(updatedUrl, isNotNull);
+      expect(updatedUrl, isNot(equals(previousUrl)));
+      expect(updatedUrl, startsWith('https://'));
+    });
+
+    test('uploadAvatar with null user throws StateError', () async {
+      // Container with no load() completion — user is still null.
+      final container = ProviderContainer(
+        overrides: [
+          useMockDataProvider.overrideWithValue(true),
+          // Override with a service that would succeed if user existed.
+          avatarUploadServiceProvider.overrideWithValue(
+            MockAvatarUploadService(),
+          ),
+        ],
+      )..listen(profileNotifierProvider, (_, _) {});
+      addTearDown(container.dispose);
+
+      // Read immediately before the async load() populates user.
+      // The notifier starts with user = AsyncValue.loading(), so userId is null.
+      expect(
+        () => container
+            .read(profileNotifierProvider.notifier)
+            .uploadAvatar('/tmp/avatar.jpg'),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('isUploadingAvatar defaults to false in initial ProfileState', () {
+      const state = ProfileState();
+      expect(state.isUploadingAvatar, isFalse);
     });
   });
 }

--- a/test/features/profile/presentation/viewmodels/profile_viewmodel_test.dart
+++ b/test/features/profile/presentation/viewmodels/profile_viewmodel_test.dart
@@ -3,7 +3,16 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:deelmarkt/core/services/repository_providers.dart';
 import 'package:deelmarkt/features/profile/data/mock/mock_avatar_upload_service.dart';
+import 'package:deelmarkt/features/profile/domain/services/avatar_upload_service.dart';
 import 'package:deelmarkt/features/profile/presentation/viewmodels/profile_viewmodel.dart';
+
+/// Avatar upload service that always throws [Exception] to simulate failure.
+class _ThrowingAvatarService implements AvatarUploadService {
+  @override
+  Future<String> upload({required String userId, required String filePath}) {
+    throw Exception('Simulated upload failure');
+  }
+}
 
 /// Creates a container with mock data, subscribes to keep the provider alive,
 /// and waits for the initial load to complete.
@@ -171,6 +180,41 @@ void main() {
     test('isUploadingAvatar defaults to false in initial ProfileState', () {
       const state = ProfileState();
       expect(state.isUploadingAvatar, isFalse);
+    });
+
+    test('uploadAvatar failure reverts avatarUrl to previous value', () async {
+      final container = ProviderContainer(
+        overrides: [
+          useMockDataProvider.overrideWithValue(true),
+          avatarUploadServiceProvider.overrideWithValue(
+            _ThrowingAvatarService(),
+          ),
+        ],
+      )..listen(profileNotifierProvider, (_, _) {});
+      addTearDown(container.dispose);
+
+      // Wait for the initial load to populate user.
+      await Future<void>.delayed(const Duration(milliseconds: 800));
+
+      final previousUrl =
+          container.read(profileNotifierProvider).user.requireValue?.avatarUrl;
+
+      // uploadAvatar rethrows after reverting — catch to inspect state.
+      await expectLater(
+        () => container
+            .read(profileNotifierProvider.notifier)
+            .uploadAvatar('/tmp/avatar.jpg'),
+        throwsException,
+      );
+
+      final afterUrl =
+          container.read(profileNotifierProvider).user.requireValue?.avatarUrl;
+
+      expect(afterUrl, equals(previousUrl));
+      expect(
+        container.read(profileNotifierProvider).isUploadingAvatar,
+        isFalse,
+      );
     });
   });
 }

--- a/test/features/profile/presentation/widgets/delete_address_dialog_test.dart
+++ b/test/features/profile/presentation/widgets/delete_address_dialog_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:deelmarkt/core/domain/entities/dutch_address.dart';
+import 'package:deelmarkt/features/profile/presentation/widgets/delete_address_dialog.dart';
+import 'package:deelmarkt/widgets/buttons/deel_button.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const _testAddress = DutchAddress(
+  postcode: '1012 AB',
+  houseNumber: '42',
+  street: 'Damrak',
+  city: 'Amsterdam',
+);
+
+Widget _dialogOpener({ValueChanged<bool?>? onResult}) {
+  return Scaffold(
+    body: Builder(
+      builder:
+          (context) => ElevatedButton(
+            onPressed: () async {
+              final result = await DeleteAddressDialog.show(
+                context,
+                _testAddress,
+              );
+              onResult?.call(result);
+            },
+            child: const Text('Open'),
+          ),
+    ),
+  );
+}
+
+Future<void> _pumpDialog(WidgetTester tester) async {
+  await pumpTestScreenWithProviders(tester, _dialogOpener());
+  await tester.tap(find.text('Open'));
+  await tester.pumpAndSettle();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('DeleteAddressDialog', () {
+    testWidgets('renders title and formatted address', (tester) async {
+      await _pumpDialog(tester);
+
+      expect(find.text('settings.deleteAddressTitle'), findsOneWidget);
+      expect(find.text(_testAddress.formatted), findsOneWidget);
+    });
+
+    testWidgets('confirm returns true', (tester) async {
+      bool? result;
+      await pumpTestScreenWithProviders(
+        tester,
+        _dialogOpener(onResult: (r) => result = r),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('action.delete'));
+      await tester.pumpAndSettle();
+
+      expect(result, isTrue);
+    });
+
+    testWidgets('cancel returns null', (tester) async {
+      bool? result = true;
+      await pumpTestScreenWithProviders(
+        tester,
+        _dialogOpener(onResult: (r) => result = r),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('action.cancel'));
+      await tester.pumpAndSettle();
+
+      expect(result, isNull);
+    });
+
+    testWidgets(
+      'barrierDismissible is false — tapping outside keeps dialog open',
+      (tester) async {
+        await _pumpDialog(tester);
+
+        // Tap the barrier area (top-left corner, outside the dialog bounds).
+        await tester.tapAt(const Offset(10, 10));
+        await tester.pumpAndSettle();
+
+        expect(find.text('settings.deleteAddressTitle'), findsOneWidget);
+      },
+    );
+
+    testWidgets('uses DeelButton destructive variant for delete', (
+      tester,
+    ) async {
+      await _pumpDialog(tester);
+
+      final buttons =
+          tester.widgetList<DeelButton>(find.byType(DeelButton)).toList();
+      final destructiveButtons = buttons.where(
+        (b) => b.variant == DeelButtonVariant.destructive,
+      );
+
+      expect(destructiveButtons, hasLength(1));
+    });
+
+    testWidgets('uses DeelButton ghost variant for cancel', (tester) async {
+      await _pumpDialog(tester);
+
+      final buttons =
+          tester.widgetList<DeelButton>(find.byType(DeelButton)).toList();
+      final ghostButtons = buttons.where(
+        (b) => b.variant == DeelButtonVariant.ghost,
+      );
+
+      expect(ghostButtons, hasLength(1));
+    });
+  });
+}

--- a/test/features/profile/presentation/widgets/listings_tab_view_navigation_test.dart
+++ b/test/features/profile/presentation/widgets/listings_tab_view_navigation_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -41,6 +42,21 @@ void main() {
       expect(find.text('empty.my_listings_action'), findsOneWidget);
     });
 
+    testWidgets('#51 — empty state onAction callback is not null', (
+      tester,
+    ) async {
+      await pumpTestWidget(
+        tester,
+        ListingsTabView(
+          listings: const AsyncValue<List<ListingEntity>>.data([]),
+          onRetry: () {},
+        ),
+      );
+
+      final emptyState = tester.widget<EmptyState>(find.byType(EmptyState));
+      expect(emptyState.onAction, isNotNull);
+    });
+
     testWidgets('#52 — listing cards have onTap wired', (tester) async {
       await pumpTestWidget(
         tester,
@@ -52,6 +68,20 @@ void main() {
 
       expect(find.byType(DeelCard), findsOneWidget);
       expect(find.text('Test Bike'), findsOneWidget);
+    });
+
+    testWidgets('#52 — listing card has Semantics wrapper', (tester) async {
+      await pumpTestWidget(
+        tester,
+        ListingsTabView(
+          listings: AsyncValue<List<ListingEntity>>.data(testListings),
+          onRetry: () {},
+        ),
+      );
+
+      // The grid item wraps DeelCard in Semantics(button: true).
+      // Verify the Semantics ancestor exists in the widget tree.
+      expect(find.byType(Semantics), findsWidgets);
     });
   });
 }

--- a/test/features/profile/presentation/widgets/profile_header_navigation_test.dart
+++ b/test/features/profile/presentation/widgets/profile_header_navigation_test.dart
@@ -1,13 +1,86 @@
 import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:deelmarkt/core/design_system/theme.dart';
+import 'package:deelmarkt/core/services/repository_providers.dart';
 import 'package:deelmarkt/features/profile/domain/entities/user_entity.dart';
 import 'package:deelmarkt/features/profile/presentation/widgets/profile_header.dart';
 import 'package:deelmarkt/widgets/badges/deel_avatar.dart';
 
-import '../../../../helpers/pump_app.dart';
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Pump [ProfileHeader] inside ProviderScope + EasyLocalization.
+///
+/// ProfileHeader is a ConsumerWidget and calls `context.locale`, so both
+/// ProviderScope (Riverpod) and EasyLocalization must be present.
+Future<void> _pumpHeader(
+  WidgetTester tester,
+  UserEntity user, {
+  List<Override> overrides = const [],
+}) async {
+  SharedPreferences.setMockInitialValues({});
+  await EasyLocalization.ensureInitialized();
+  await initializeDateFormatting('en');
+  await initializeDateFormatting('nl');
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [useMockDataProvider.overrideWithValue(true), ...overrides],
+      child: EasyLocalization(
+        supportedLocales: const [Locale('nl', 'NL'), Locale('en', 'US')],
+        fallbackLocale: const Locale('en', 'US'),
+        path: 'assets/l10n',
+        child: MaterialApp(
+          theme: DeelmarktTheme.light,
+          home: Scaffold(
+            body: Builder(
+              builder:
+                  (context) => MediaQuery(
+                    data: MediaQuery.of(
+                      context,
+                    ).copyWith(disableAnimations: true),
+                    child: SingleChildScrollView(
+                      child: ProfileHeader(user: user),
+                    ),
+                  ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  // Pump enough to let the profileNotifierProvider auto-load complete.
+  // MockUserRepository: 200ms + MockListingRepo/ReviewRepo: 500ms = 700ms total.
+  await tester.pump(const Duration(milliseconds: 200));
+  await tester.pump(const Duration(milliseconds: 600));
+  await tester.pumpAndSettle();
+}
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+final _testUser = UserEntity(
+  id: 'user-001',
+  displayName: 'Jan de Vries',
+  kycLevel: KycLevel.level1,
+  location: 'Amsterdam',
+  badges: const [BadgeType.emailVerified],
+  averageRating: 4.7,
+  reviewCount: 23,
+  responseTimeMinutes: 15,
+  createdAt: DateTime(2025, 6),
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 void main() {
   setUpAll(() async {
@@ -17,21 +90,9 @@ void main() {
     await initializeDateFormatting('nl');
   });
 
-  final testUser = UserEntity(
-    id: 'user-001',
-    displayName: 'Jan de Vries',
-    kycLevel: KycLevel.level1,
-    location: 'Amsterdam',
-    badges: const [BadgeType.emailVerified],
-    averageRating: 4.7,
-    reviewCount: 23,
-    responseTimeMinutes: 15,
-    createdAt: DateTime(2025, 6),
-  );
-
   group('ProfileHeader avatar picker wiring (#53)', () {
     testWidgets('edit overlay is enabled on avatar', (tester) async {
-      await pumpLocalizedWidget(tester, ProfileHeader(user: testUser));
+      await _pumpHeader(tester, _testUser);
 
       final avatar = tester.widget<DeelAvatar>(find.byType(DeelAvatar));
       expect(avatar.showEditOverlay, isTrue);
@@ -41,7 +102,7 @@ void main() {
     testWidgets('tapping avatar opens image picker bottom sheet', (
       tester,
     ) async {
-      await pumpLocalizedWidget(tester, ProfileHeader(user: testUser));
+      await _pumpHeader(tester, _testUser);
 
       await tester.tap(find.byType(DeelAvatar));
       await tester.pumpAndSettle();
@@ -49,6 +110,28 @@ void main() {
       expect(find.text('profile.pickPhoto'), findsOneWidget);
       expect(find.text('profile.takePhoto'), findsOneWidget);
       expect(find.text('profile.chooseFromGallery'), findsOneWidget);
+    });
+
+    testWidgets('no loading spinner when isUploadingAvatar is false', (
+      tester,
+    ) async {
+      await _pumpHeader(tester, _testUser);
+
+      // CircularProgressIndicator only shown during upload.
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+    });
+
+    testWidgets('displays user displayName', (tester) async {
+      await _pumpHeader(tester, _testUser);
+
+      expect(find.text(_testUser.displayName), findsOneWidget);
+    });
+
+    testWidgets('DeelAvatar size is large', (tester) async {
+      await _pumpHeader(tester, _testUser);
+
+      final avatar = tester.widget<DeelAvatar>(find.byType(DeelAvatar));
+      expect(avatar.size, DeelAvatarSize.large);
     });
   });
 }

--- a/test/features/profile/presentation/widgets/profile_header_navigation_test.dart
+++ b/test/features/profile/presentation/widgets/profile_header_navigation_test.dart
@@ -8,6 +8,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:deelmarkt/core/design_system/theme.dart';
 import 'package:deelmarkt/core/services/repository_providers.dart';
 import 'package:deelmarkt/features/profile/domain/entities/user_entity.dart';
+import 'package:deelmarkt/features/profile/presentation/viewmodels/profile_viewmodel.dart';
 import 'package:deelmarkt/features/profile/presentation/widgets/profile_header.dart';
 import 'package:deelmarkt/widgets/badges/deel_avatar.dart';
 
@@ -60,6 +61,15 @@ Future<void> _pumpHeader(
   await tester.pump(const Duration(milliseconds: 200));
   await tester.pump(const Duration(milliseconds: 600));
   await tester.pumpAndSettle();
+}
+
+// ---------------------------------------------------------------------------
+// Stub notifier — returns isUploadingAvatar: true immediately
+// ---------------------------------------------------------------------------
+
+class _UploadingProfileNotifier extends ProfileNotifier {
+  @override
+  ProfileState build() => const ProfileState(isUploadingAvatar: true);
 }
 
 // ---------------------------------------------------------------------------
@@ -119,6 +129,52 @@ void main() {
 
       // CircularProgressIndicator only shown during upload.
       expect(find.byType(CircularProgressIndicator), findsNothing);
+    });
+
+    testWidgets('shows spinner overlay when isUploadingAvatar is true', (
+      tester,
+    ) async {
+      // Use pump (not pumpAndSettle) — CircularProgressIndicator is an
+      // infinite animation and pumpAndSettle would time out.
+      SharedPreferences.setMockInitialValues({});
+      await EasyLocalization.ensureInitialized();
+      await initializeDateFormatting('en');
+      await initializeDateFormatting('nl');
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            useMockDataProvider.overrideWithValue(true),
+            profileNotifierProvider.overrideWith(
+              () => _UploadingProfileNotifier(),
+            ),
+          ],
+          child: EasyLocalization(
+            supportedLocales: const [Locale('nl', 'NL'), Locale('en', 'US')],
+            fallbackLocale: const Locale('en', 'US'),
+            path: 'assets/l10n',
+            child: MaterialApp(
+              theme: DeelmarktTheme.light,
+              home: Scaffold(
+                body: Builder(
+                  builder:
+                      (context) => MediaQuery(
+                        data: MediaQuery.of(
+                          context,
+                        ).copyWith(disableAnimations: true),
+                        child: SingleChildScrollView(
+                          child: ProfileHeader(user: _testUser),
+                        ),
+                      ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump(); // single frame — no settle needed
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
     });
 
     testWidgets('displays user displayName', (tester) async {

--- a/test/features/profile/presentation/widgets/profile_header_test.dart
+++ b/test/features/profile/presentation/widgets/profile_header_test.dart
@@ -1,14 +1,89 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:deelmarkt/core/design_system/theme.dart';
+import 'package:deelmarkt/core/services/repository_providers.dart';
 import 'package:deelmarkt/features/profile/domain/entities/user_entity.dart';
 import 'package:deelmarkt/features/profile/presentation/widgets/profile_header.dart';
 import 'package:deelmarkt/widgets/badges/deel_avatar.dart';
 
-import '../../../../helpers/pump_app.dart';
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+/// Pumps [ProfileHeader] inside ProviderScope + EasyLocalization.
+///
+/// ProfileHeader is a ConsumerWidget that reads profileNotifierProvider,
+/// so ProviderScope is required. useMockDataProvider is forced to true so
+/// mock repositories are used (no real Supabase calls in tests).
+///
+/// The mock load() has a 200ms user delay + 500ms listings/reviews delay,
+/// so we drain timers before settling.
+Future<void> _pumpHeader(
+  WidgetTester tester,
+  UserEntity user, {
+  List<Override> overrides = const [],
+}) async {
+  SharedPreferences.setMockInitialValues({});
+  await EasyLocalization.ensureInitialized();
+  await initializeDateFormatting('en');
+  await initializeDateFormatting('nl');
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [useMockDataProvider.overrideWithValue(true), ...overrides],
+      child: EasyLocalization(
+        supportedLocales: const [Locale('nl', 'NL'), Locale('en', 'US')],
+        fallbackLocale: const Locale('en', 'US'),
+        path: 'assets/l10n',
+        child: MaterialApp(
+          theme: DeelmarktTheme.light,
+          home: Scaffold(
+            body: Builder(
+              builder:
+                  (context) => MediaQuery(
+                    data: MediaQuery.of(
+                      context,
+                    ).copyWith(disableAnimations: true),
+                    child: SingleChildScrollView(
+                      child: ProfileHeader(user: user),
+                    ),
+                  ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  // Drain mock repo timers: 200ms user + 600ms listings/reviews.
+  await tester.pump(const Duration(milliseconds: 200));
+  await tester.pump(const Duration(milliseconds: 600));
+  await tester.pumpAndSettle();
+}
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+final _testUser = UserEntity(
+  id: 'user-001',
+  displayName: 'Jan de Vries',
+  kycLevel: KycLevel.level1,
+  location: 'Amsterdam',
+  badges: const [BadgeType.emailVerified],
+  averageRating: 4.7,
+  reviewCount: 23,
+  responseTimeMinutes: 15,
+  createdAt: DateTime(2025, 6),
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 void main() {
   setUpAll(() async {
@@ -18,59 +93,47 @@ void main() {
     await initializeDateFormatting('nl');
   });
 
-  final testUser = UserEntity(
-    id: 'user-001',
-    displayName: 'Jan de Vries',
-    kycLevel: KycLevel.level1,
-    location: 'Amsterdam',
-    badges: const [BadgeType.emailVerified],
-    averageRating: 4.7,
-    reviewCount: 23,
-    responseTimeMinutes: 15,
-    createdAt: DateTime(2025, 6),
-  );
-
   group('ProfileHeader', () {
     testWidgets('renders DeelAvatar with correct display name', (tester) async {
-      await pumpLocalizedWidget(tester, ProfileHeader(user: testUser));
+      await _pumpHeader(tester, _testUser);
 
       final avatar = tester.widget<DeelAvatar>(find.byType(DeelAvatar));
       expect(avatar.displayName, 'Jan de Vries');
     });
 
     testWidgets('renders DeelAvatar with large size', (tester) async {
-      await pumpLocalizedWidget(tester, ProfileHeader(user: testUser));
+      await _pumpHeader(tester, _testUser);
 
       final avatar = tester.widget<DeelAvatar>(find.byType(DeelAvatar));
       expect(avatar.size, DeelAvatarSize.large);
     });
 
     testWidgets('shows display name as text', (tester) async {
-      await pumpLocalizedWidget(tester, ProfileHeader(user: testUser));
+      await _pumpHeader(tester, _testUser);
 
       expect(find.text('Jan de Vries'), findsOneWidget);
     });
 
     testWidgets('shows member since date', (tester) async {
-      await pumpLocalizedWidget(tester, ProfileHeader(user: testUser));
+      await _pumpHeader(tester, _testUser);
 
       // DateFormat.yMMM('en') produces e.g. "Jun 2025"
       expect(find.textContaining('Jun 2025'), findsOneWidget);
     });
 
     testWidgets('shows edit overlay on avatar', (tester) async {
-      await pumpLocalizedWidget(tester, ProfileHeader(user: testUser));
+      await _pumpHeader(tester, _testUser);
 
       final avatar = tester.widget<DeelAvatar>(find.byType(DeelAvatar));
       expect(avatar.showEditOverlay, isTrue);
     });
 
     testWidgets('renders with user that has avatar URL', (tester) async {
-      final userWithAvatar = testUser.copyWith(
+      final userWithAvatar = _testUser.copyWith(
         avatarUrl: 'https://example.com/avatar.jpg',
       );
 
-      await pumpLocalizedWidget(tester, ProfileHeader(user: userWithAvatar));
+      await _pumpHeader(tester, userWithAvatar);
 
       final avatar = tester.widget<DeelAvatar>(find.byType(DeelAvatar));
       expect(avatar.imageUrl, 'https://example.com/avatar.jpg');
@@ -79,7 +142,7 @@ void main() {
     testWidgets('tapping avatar opens bottom sheet with image picker options', (
       tester,
     ) async {
-      await pumpLocalizedWidget(tester, ProfileHeader(user: testUser));
+      await _pumpHeader(tester, _testUser);
 
       await tester.tap(find.byType(DeelAvatar));
       await tester.pumpAndSettle();
@@ -92,7 +155,7 @@ void main() {
     testWidgets('tapping camera option in bottom sheet closes it', (
       tester,
     ) async {
-      await pumpLocalizedWidget(tester, ProfileHeader(user: testUser));
+      await _pumpHeader(tester, _testUser);
 
       await tester.tap(find.byType(DeelAvatar));
       await tester.pumpAndSettle();
@@ -106,7 +169,7 @@ void main() {
     testWidgets('tapping gallery option in bottom sheet closes it', (
       tester,
     ) async {
-      await pumpLocalizedWidget(tester, ProfileHeader(user: testUser));
+      await _pumpHeader(tester, _testUser);
 
       await tester.tap(find.byType(DeelAvatar));
       await tester.pumpAndSettle();
@@ -118,7 +181,7 @@ void main() {
     });
 
     testWidgets('bottom sheet has two ListTile options', (tester) async {
-      await pumpLocalizedWidget(tester, ProfileHeader(user: testUser));
+      await _pumpHeader(tester, _testUser);
 
       await tester.tap(find.byType(DeelAvatar));
       await tester.pumpAndSettle();
@@ -127,16 +190,16 @@ void main() {
     });
 
     testWidgets('formats member since for single-digit month', (tester) async {
-      final januaryUser = testUser.copyWith(createdAt: DateTime(2024));
-      await pumpLocalizedWidget(tester, ProfileHeader(user: januaryUser));
+      final januaryUser = _testUser.copyWith(createdAt: DateTime(2024));
+      await _pumpHeader(tester, januaryUser);
 
       // DateFormat.yMMM('en') for January 2024 → "Jan 2024"
       expect(find.textContaining('Jan 2024'), findsOneWidget);
     });
 
     testWidgets('formats member since for double-digit month', (tester) async {
-      final decUser = testUser.copyWith(createdAt: DateTime(2025, 12));
-      await pumpLocalizedWidget(tester, ProfileHeader(user: decUser));
+      final decUser = _testUser.copyWith(createdAt: DateTime(2025, 12));
+      await _pumpHeader(tester, decUser);
 
       // DateFormat.yMMM('en') for December 2025 → "Dec 2025"
       expect(find.textContaining('Dec 2025'), findsOneWidget);
@@ -152,7 +215,7 @@ void main() {
         createdAt: DateTime(2026, 3),
       );
 
-      await pumpLocalizedWidget(tester, ProfileHeader(user: noAvatarUser));
+      await _pumpHeader(tester, noAvatarUser);
 
       final avatar = tester.widget<DeelAvatar>(find.byType(DeelAvatar));
       expect(avatar.imageUrl, isNull);
@@ -161,13 +224,13 @@ void main() {
     });
 
     testWidgets('member since text includes the key path', (tester) async {
-      await pumpLocalizedWidget(tester, ProfileHeader(user: testUser));
+      await _pumpHeader(tester, _testUser);
 
       expect(find.textContaining('profile.memberSince'), findsOneWidget);
     });
 
     testWidgets('renders onEditTap callback on avatar', (tester) async {
-      await pumpLocalizedWidget(tester, ProfileHeader(user: testUser));
+      await _pumpHeader(tester, _testUser);
 
       final avatar = tester.widget<DeelAvatar>(find.byType(DeelAvatar));
       expect(avatar.onEditTap, isNotNull);

--- a/test/features/profile/presentation/widgets/profile_header_test.dart
+++ b/test/features/profile/presentation/widgets/profile_header_test.dart
@@ -2,14 +2,51 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
 import 'package:intl/date_symbol_data_local.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:deelmarkt/core/design_system/theme.dart';
 import 'package:deelmarkt/core/services/repository_providers.dart';
 import 'package:deelmarkt/features/profile/domain/entities/user_entity.dart';
+import 'package:deelmarkt/features/profile/presentation/viewmodels/profile_viewmodel.dart';
 import 'package:deelmarkt/features/profile/presentation/widgets/profile_header.dart';
 import 'package:deelmarkt/widgets/badges/deel_avatar.dart';
+
+// ---------------------------------------------------------------------------
+// ImagePicker mock — replaces the platform channel with a controllable stub.
+// ---------------------------------------------------------------------------
+
+class _MockImagePickerPlatform extends Mock
+    with MockPlatformInterfaceMixin
+    implements ImagePickerPlatform {
+  XFile? result;
+
+  @override
+  Future<XFile?> getImageFromSource({
+    required ImageSource source,
+    ImagePickerOptions options = const ImagePickerOptions(),
+  }) async => result;
+}
+
+// ---------------------------------------------------------------------------
+// Notifier stub — uploadAvatar always throws to exercise the error path.
+// ---------------------------------------------------------------------------
+
+class _ThrowingUploadNotifier extends ProfileNotifier {
+  @override
+  ProfileState build() => ProfileState(
+    user: AsyncValue.data(_testUser),
+    listings: const AsyncValue.data([]),
+    reviews: const AsyncValue.data([]),
+  );
+
+  @override
+  Future<void> uploadAvatar(String imagePath) async =>
+      throw Exception('simulated upload failure');
+}
 
 // ---------------------------------------------------------------------------
 // Helper
@@ -234,6 +271,86 @@ void main() {
 
       final avatar = tester.widget<DeelAvatar>(find.byType(DeelAvatar));
       expect(avatar.onEditTap, isNotNull);
+    });
+
+    testWidgets(
+      'picking image via camera triggers uploadAvatar with no error snackbar',
+      (tester) async {
+        final mockPicker =
+            _MockImagePickerPlatform()..result = XFile('/mock/avatar.jpg');
+        ImagePickerPlatform.instance = mockPicker;
+        final originalPicker = ImagePickerPlatform.instance;
+        addTearDown(() => ImagePickerPlatform.instance = originalPicker);
+
+        await _pumpHeader(tester, _testUser);
+
+        await tester.tap(find.byType(DeelAvatar));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('profile.takePhoto'));
+        // Allow MockAvatarUploadService 300ms delay to complete.
+        await tester.pump(const Duration(milliseconds: 400));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(SnackBar), findsNothing);
+      },
+    );
+
+    testWidgets('upload failure shows avatarUploadFailed snackbar', (
+      tester,
+    ) async {
+      final mockPicker =
+          _MockImagePickerPlatform()..result = XFile('/mock/avatar.jpg');
+      ImagePickerPlatform.instance = mockPicker;
+      final originalPicker = ImagePickerPlatform.instance;
+      addTearDown(() => ImagePickerPlatform.instance = originalPicker);
+
+      SharedPreferences.setMockInitialValues({});
+      await EasyLocalization.ensureInitialized();
+      await initializeDateFormatting('en');
+      await initializeDateFormatting('nl');
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            useMockDataProvider.overrideWithValue(true),
+            profileNotifierProvider.overrideWith(
+              () => _ThrowingUploadNotifier(),
+            ),
+          ],
+          child: EasyLocalization(
+            supportedLocales: const [Locale('nl', 'NL'), Locale('en', 'US')],
+            fallbackLocale: const Locale('en', 'US'),
+            path: 'assets/l10n',
+            child: MaterialApp(
+              theme: DeelmarktTheme.light,
+              home: Scaffold(
+                body: Builder(
+                  builder:
+                      (context) => MediaQuery(
+                        data: MediaQuery.of(
+                          context,
+                        ).copyWith(disableAnimations: true),
+                        child: SingleChildScrollView(
+                          child: ProfileHeader(user: _testUser),
+                        ),
+                      ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(DeelAvatar));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('profile.takePhoto'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('profile.avatarUploadFailed'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary

- **#53 Avatar upload** — `AvatarUploadService` interface + `SupabaseAvatarUploadService` + `MockAvatarUploadService`; `ProfileHeader` → `ConsumerWidget` with real upload, spinner overlay, optimistic revert on failure, error snackbar; `ProfileNotifier.uploadAvatar()` with `isUploadingAvatar` state flag; `avatarUploadServiceProvider` with mock/real gate
- **#50 Delete address confirmation** — `DeleteAddressDialog` (`barrierDismissible: false`, destructive variant); settings screen `onDelete` gated behind confirmed dialog; l10n keys EN + NL
- **#51 Sell-from-empty nav tests** — empty state `onAction` callback wired; `SellerHomeEmptyView` button label + `onPressed` verified
- **#52 Listing detail nav tests** — listing card Semantics verified; seller card rendered + `onViewProfile` wired

## Epic / Task

Sprint 5–8 deferred tasks · Issues #50 #51 #52 #53

## Type

- [x] Feature
- [x] Bug fix

## Epic Acceptance Criteria Coverage

| Epic Criterion | Status | Notes |
|:---------------|:-------|:------|
| Avatar picker opens on tap | Covered | Bottom sheet + ImagePicker wired |
| Avatar upload updates profile | Covered | `uploadAvatar` → Storage → `updateProfile` |
| Delete address requires confirmation | Covered | `DeleteAddressDialog` with `barrierDismissible: false` |
| Sell CTA navigates to sell screen | Covered | Both `goBranch` + `context.go` entry points tested |
| Profile listing card opens detail | Covered | `onTap` wired via `pushNamed` |
| Seller card in detail opens profile | Covered | `onViewProfile` wired |

## Schema Verification

N/A — no Edge Functions or migrations. `avatars` Storage bucket tracked in issue #148 (assigned to reso).

## Checklist

- [x] `dart format .` passes
- [x] `flutter analyze` — zero warnings
- [x] `flutter test` — all passing (572 profile tests + full suite)
- [x] Coverage ≥70%
- [x] No hardcoded strings (all in l10n)
- [x] No hardcoded colours (all from `DeelmarktColors`)
- [x] No secrets in code
- [x] Sprint plan #50 #51 #52 #53 marked complete
- [x] AgentShield security scan: Grade A (100/100)

## Tier-1 Retrospective Audit Fixes (commit f651171)

Two issues found and closed after implementation:

| Severity | Finding | Fix |
|----------|---------|-----|
| HIGH | `on Exception` missed `StateError` in `uploadAvatar` + `_showImagePicker`, leaving `isUploadingAvatar` stuck at `true` permanently | Changed to `on Object catch (_)` |
| LOW | Dead `settings.deleteAddressBody` l10n key — never used in code | Removed from EN + NL JSON |

## Backend Dependency

Issue #148 (assigned to **reso**): create `avatars` Supabase Storage bucket + RLS. All avatar work uses `MockAvatarUploadService` until bucket is provisioned.