### PR TITLE
feat(a11y): P-42 — WCAG 2.2 AA accessibility audit

### DIFF
--- a/lib/features/auth/presentation/widgets/consent_checkboxes.dart
+++ b/lib/features/auth/presentation/widgets/consent_checkboxes.dart
@@ -1,5 +1,4 @@
 import 'package:easy_localization/easy_localization.dart';
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -30,80 +29,84 @@ class ConsentCheckboxes extends StatefulWidget {
 }
 
 class _ConsentCheckboxesState extends State<ConsentCheckboxes> {
-  late final TapGestureRecognizer _termsRecognizer;
-  late final TapGestureRecognizer _privacyRecognizer;
-
-  @override
-  void initState() {
-    super.initState();
-    _termsRecognizer =
-        TapGestureRecognizer()
-          ..onTap = () => launchUrl(Uri.parse(AppConstants.termsUrl));
-    _privacyRecognizer =
-        TapGestureRecognizer()
-          ..onTap = () => launchUrl(Uri.parse(AppConstants.privacyUrl));
-  }
-
-  @override
-  void dispose() {
-    _termsRecognizer.dispose();
-    _privacyRecognizer.dispose();
-    super.dispose();
-  }
-
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final linkStyle = theme.textTheme.bodyMedium?.copyWith(
-      color: DeelmarktColors.secondary,
-      decoration: TextDecoration.underline,
-    );
-
     return Column(
       children: [
-        CheckboxListTile(
+        _ConsentRow(
           value: widget.termsAccepted,
           onChanged:
               widget.enabled ? (v) => widget.onTermsChanged(v ?? false) : null,
-          controlAffinity: ListTileControlAffinity.leading,
-          contentPadding: EdgeInsets.zero,
-          title: Text.rich(
-            TextSpan(
-              text: 'auth.terms_agree_prefix'.tr(),
-              children: [
-                TextSpan(
-                  text: 'auth.terms_link'.tr(),
-                  style: linkStyle,
-                  recognizer: _termsRecognizer,
-                ),
-              ],
-            ),
-            style: theme.textTheme.bodyMedium,
-          ),
+          prefixKey: 'auth.terms_agree_prefix',
+          linkKey: 'auth.terms_link',
+          linkUrl: AppConstants.termsUrl,
+          theme: theme,
         ),
-        CheckboxListTile(
+        _ConsentRow(
           value: widget.privacyAccepted,
           onChanged:
               widget.enabled
                   ? (v) => widget.onPrivacyChanged(v ?? false)
                   : null,
-          controlAffinity: ListTileControlAffinity.leading,
-          contentPadding: EdgeInsets.zero,
-          title: Text.rich(
-            TextSpan(
-              text: 'auth.privacy_agree_prefix'.tr(),
-              children: [
-                TextSpan(
-                  text: 'auth.privacy_link'.tr(),
-                  style: linkStyle,
-                  recognizer: _privacyRecognizer,
-                ),
-              ],
-            ),
-            style: theme.textTheme.bodyMedium,
-          ),
+          prefixKey: 'auth.privacy_agree_prefix',
+          linkKey: 'auth.privacy_link',
+          linkUrl: AppConstants.privacyUrl,
+          theme: theme,
         ),
       ],
+    );
+  }
+}
+
+/// Single consent checkbox row with an accessible link in the title.
+///
+/// Uses [Semantics(link: true)] around the tappable URL text instead of
+/// [TapGestureRecognizer] inside a [TextSpan] — the recogniser approach
+/// does not expose the [link] semantic flag to TalkBack/VoiceOver, causing
+/// screen readers to announce it as plain text rather than a navigable link
+/// (WCAG 2.4.4 Link Purpose, Level AA).
+class _ConsentRow extends StatelessWidget {
+  const _ConsentRow({
+    required this.value,
+    required this.onChanged,
+    required this.prefixKey,
+    required this.linkKey,
+    required this.linkUrl,
+    required this.theme,
+  });
+
+  final bool value;
+  final ValueChanged<bool?>? onChanged;
+  final String prefixKey;
+  final String linkKey;
+  final String linkUrl;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    final linkStyle = theme.textTheme.bodyMedium?.copyWith(
+      color: DeelmarktColors.secondary,
+      decoration: TextDecoration.underline,
+    );
+
+    return CheckboxListTile(
+      value: value,
+      onChanged: onChanged,
+      controlAffinity: ListTileControlAffinity.leading,
+      contentPadding: EdgeInsets.zero,
+      title: Wrap(
+        children: [
+          Text(prefixKey.tr(), style: theme.textTheme.bodyMedium),
+          Semantics(
+            link: true,
+            child: InkWell(
+              onTap: () => launchUrl(Uri.parse(linkUrl)),
+              child: Text(linkKey.tr(), style: linkStyle),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/home/presentation/widgets/section_header.dart
+++ b/lib/features/home/presentation/widgets/section_header.dart
@@ -33,6 +33,7 @@ class SectionHeader extends StatelessWidget {
           if (actionLabel != null && onAction != null)
             Semantics(
               button: true,
+              label: actionLabel,
               child: Material(
                 color: Colors.transparent,
                 child: InkWell(

--- a/lib/widgets/cards/deel_card_image.dart
+++ b/lib/widgets/cards/deel_card_image.dart
@@ -6,6 +6,11 @@ import 'package:deelmarkt/core/design_system/colors.dart';
 import 'package:deelmarkt/core/design_system/radius.dart';
 
 /// Image component for [DeelCard] with Hero transition, loading, and error states.
+///
+/// The image is wrapped in [ExcludeSemantics] because [DeelCard] already provides
+/// a comprehensive semantic label (price + title) for the whole card. Exposing the
+/// unlabelled image node separately would cause TalkBack/VoiceOver to announce
+/// "image" without context, which is worse than omitting it.
 class DeelCardImage extends StatelessWidget {
   const DeelCardImage({
     required this.imageUrl,
@@ -31,27 +36,29 @@ class DeelCardImage extends StatelessWidget {
         borderRadius ??
         const BorderRadius.vertical(top: Radius.circular(DeelmarktRadius.xl));
 
-    Widget image = AspectRatio(
-      aspectRatio: aspectRatio,
-      child: ClipRRect(
-        borderRadius: effectiveBorderRadius,
-        child: Image.network(
-          imageUrl,
-          fit: BoxFit.cover,
-          frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
-            if (wasSynchronouslyLoaded || frame != null) {
-              return AnimatedOpacity(
-                opacity: 1.0,
-                duration: duration,
-                curve: DeelmarktAnimation.curveStandard,
-                child: child,
-              );
-            }
-            return _placeholder(context);
-          },
-          errorBuilder: (context, error, stackTrace) {
-            return _placeholder(context);
-          },
+    Widget image = ExcludeSemantics(
+      child: AspectRatio(
+        aspectRatio: aspectRatio,
+        child: ClipRRect(
+          borderRadius: effectiveBorderRadius,
+          child: Image.network(
+            imageUrl,
+            fit: BoxFit.cover,
+            frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
+              if (wasSynchronouslyLoaded || frame != null) {
+                return AnimatedOpacity(
+                  opacity: 1.0,
+                  duration: duration,
+                  curve: DeelmarktAnimation.curveStandard,
+                  child: child,
+                );
+              }
+              return _placeholder(context);
+            },
+            errorBuilder: (context, error, stackTrace) {
+              return _placeholder(context);
+            },
+          ),
         ),
       ),
     );

--- a/test/features/auth/presentation/pr33_verification_test.dart
+++ b/test/features/auth/presentation/pr33_verification_test.dart
@@ -702,24 +702,21 @@ void main() {
         reason: 'Privacy checkbox should start unchecked',
       );
 
-      // Terms and Privacy use Text.rich with TextSpan — find via rich text
-      // The combined text for terms contains the prefix + link text
+      // Terms and Privacy use separate Text widgets inside a Wrap
+      // (refactored from Text.rich for WCAG 2.4.4 link semantics).
+      // l10n keys are used as fallback text when localization is not loaded.
       expect(
         find.byWidgetPredicate(
-          (w) =>
-              w is Text &&
-              w.textSpan?.toPlainText().contains('auth.terms') == true,
+          (w) => w is Text && (w.data?.contains('auth.terms') == true),
         ),
-        findsOneWidget,
+        findsWidgets,
         reason: 'Terms checkbox should contain terms text',
       );
       expect(
         find.byWidgetPredicate(
-          (w) =>
-              w is Text &&
-              w.textSpan?.toPlainText().contains('auth.privacy') == true,
+          (w) => w is Text && (w.data?.contains('auth.privacy') == true),
         ),
-        findsOneWidget,
+        findsWidgets,
         reason: 'Privacy checkbox should contain privacy text',
       );
     });

--- a/test/features/auth/presentation/widgets/consent_checkboxes_test.dart
+++ b/test/features/auth/presentation/widgets/consent_checkboxes_test.dart
@@ -1,0 +1,107 @@
+import 'package:deelmarkt/features/auth/presentation/widgets/consent_checkboxes.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Widget buildSubject({
+    bool termsAccepted = false,
+    bool privacyAccepted = false,
+    ValueChanged<bool>? onTermsChanged,
+    ValueChanged<bool>? onPrivacyChanged,
+    bool enabled = true,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: ConsentCheckboxes(
+          termsAccepted: termsAccepted,
+          privacyAccepted: privacyAccepted,
+          onTermsChanged: onTermsChanged ?? (_) {},
+          onPrivacyChanged: onPrivacyChanged ?? (_) {},
+          enabled: enabled,
+        ),
+      ),
+    );
+  }
+
+  group('ConsentCheckboxes', () {
+    testWidgets('renders two CheckboxListTile widgets', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      expect(find.byType(CheckboxListTile), findsNWidgets(2));
+    });
+
+    testWidgets('calls onTermsChanged when terms checkbox is toggled', (
+      tester,
+    ) async {
+      bool? captured;
+      await tester.pumpWidget(
+        buildSubject(onTermsChanged: (v) => captured = v),
+      );
+
+      // Tap the Checkbox widget directly (leading position) to avoid
+      // the InkWell link inside the title Wrap intercepting the gesture.
+      final checkboxes = find.byType(Checkbox);
+      await tester.tap(checkboxes.first);
+      await tester.pump();
+
+      expect(captured, isTrue);
+    });
+
+    testWidgets('calls onPrivacyChanged when privacy checkbox is toggled', (
+      tester,
+    ) async {
+      bool? captured;
+      await tester.pumpWidget(
+        buildSubject(onPrivacyChanged: (v) => captured = v),
+      );
+
+      final checkboxes = find.byType(Checkbox);
+      await tester.tap(checkboxes.last);
+      await tester.pump();
+
+      expect(captured, isTrue);
+    });
+
+    testWidgets('checkboxes are disabled when enabled is false', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject(enabled: false));
+
+      final tiles =
+          tester
+              .widgetList<CheckboxListTile>(find.byType(CheckboxListTile))
+              .toList();
+
+      expect(tiles.every((t) => t.onChanged == null), isTrue);
+    });
+
+    testWidgets('link widgets have Semantics with link: true', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
+
+      final semanticsList =
+          tester.widgetList<Semantics>(find.byType(Semantics)).toList();
+      final linkSemantics =
+          semanticsList.where((s) => s.properties.link == true).toList();
+
+      expect(linkSemantics.length, greaterThanOrEqualTo(2));
+    });
+
+    testWidgets('reflects termsAccepted initial value', (tester) async {
+      await tester.pumpWidget(buildSubject(termsAccepted: true));
+
+      final tile = tester.widget<CheckboxListTile>(
+        find.byType(CheckboxListTile).first,
+      );
+      expect(tile.value, isTrue);
+    });
+
+    testWidgets('reflects privacyAccepted initial value', (tester) async {
+      await tester.pumpWidget(buildSubject(privacyAccepted: true));
+
+      final tile = tester.widget<CheckboxListTile>(
+        find.byType(CheckboxListTile).last,
+      );
+      expect(tile.value, isTrue);
+    });
+  });
+}

--- a/test/widgets/cards/deel_card_image_test.dart
+++ b/test/widgets/cards/deel_card_image_test.dart
@@ -1,0 +1,51 @@
+import 'package:deelmarkt/widgets/cards/deel_card_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'deel_card_test_helper.dart';
+
+void main() {
+  const testUrl = 'https://example.com/img.jpg';
+
+  Widget buildSubject({
+    String imageUrl = testUrl,
+    double aspectRatio = 4 / 3,
+    String? heroTag,
+  }) {
+    return buildCardApp(
+      child: DeelCardImage(
+        imageUrl: imageUrl,
+        aspectRatio: aspectRatio,
+        heroTag: heroTag,
+      ),
+    );
+  }
+
+  group('DeelCardImage', () {
+    testWidgets('wraps image in ExcludeSemantics (decorative)', (tester) async {
+      await tester.pumpWidget(buildSubject());
+
+      expect(find.byType(ExcludeSemantics), findsAtLeastNWidgets(1));
+    });
+
+    testWidgets('does not wrap in Hero when heroTag is null', (tester) async {
+      await tester.pumpWidget(buildSubject());
+
+      expect(find.byType(Hero), findsNothing);
+    });
+
+    testWidgets('wraps in Hero when heroTag is provided', (tester) async {
+      await tester.pumpWidget(buildSubject(heroTag: 'listing-42'));
+
+      final hero = tester.widget<Hero>(find.byType(Hero));
+      expect(hero.tag, 'listing-42');
+    });
+
+    testWidgets('respects given aspectRatio', (tester) async {
+      await tester.pumpWidget(buildSubject(aspectRatio: 1.0));
+
+      final aspectWidget = tester.widget<AspectRatio>(find.byType(AspectRatio));
+      expect(aspectWidget.aspectRatio, 1.0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- **consent_checkboxes**: Replace `TapGestureRecognizer` inside `TextSpan` with `Semantics(link: true)` + `InkWell` — fixes WCAG 2.4.4 Link Purpose (TalkBack/VoiceOver now announces links as navigable, not plain text)
- **section_header**: Add `label: actionLabel` to `Semantics(button: true)` — action button was unlabelled for screen readers
- **deel_card_image**: Wrap in `ExcludeSemantics` — `DeelCard` already provides a complete `price + title` semantic label; the bare image node caused TalkBack to announce "image" without context

## Test plan

- [ ] `consent_checkboxes_test.dart` — 6 new tests: renders, toggle callbacks, disabled state, `Semantics(link: true)` presence, initial values
- [ ] `deel_card_image_test.dart` — 4 new tests: `ExcludeSemantics` presence, Hero absent/present, aspect ratio
- [ ] `pr33_verification_test.dart` — updated predicate to match new `Wrap`-based structure (was checking `TextSpan.toPlainText`, now checks `Text.data`)
- [ ] All 3279 tests passing locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)