### PR TITLE
chore(infra): R-18/R-29 pg_cron schedules + avatars bucket (issues #144 #148)

### DIFF
--- a/lib/features/profile/data/services/supabase_avatar_upload_service.dart
+++ b/lib/features/profile/data/services/supabase_avatar_upload_service.dart
@@ -11,10 +11,15 @@ import 'package:deelmarkt/features/profile/domain/services/avatar_upload_service
 /// Path pattern: `avatars/<userId>/<timestamp>.<ext>`
 /// RLS enforces folder-level isolation per user.
 ///
-/// Bucket is public — [getPublicUrl] resolves without a signed-URL TTL so
-/// avatars render on profile cards and listings. See migration
-/// `supabase/migrations/20260415150000_r05_avatars_bucket.sql` for the
-/// bucket + RLS definition.
+/// TODO(#148): `avatars` bucket + RLS must be provisioned by reso before
+/// this service is used in production. Until then, [MockAvatarUploadService]
+/// is used via the `useMockDataProvider` gate in [avatarUploadServiceProvider].
+///
+/// TODO(#148): Decide public vs private bucket before provisioning.
+/// `getPublicUrl()` returns a URL that 403s if the bucket is private (GDPR
+/// concern for user PII). Options: public bucket, signed URL with TTL, or
+/// Cloudinary pipeline like listings-images. Agree with reso before creating
+/// the bucket migration.
 ///
 /// Reference: docs/screens/07-profile/01-own-profile.md
 class SupabaseAvatarUploadService implements AvatarUploadService {

--- a/lib/features/profile/data/services/supabase_avatar_upload_service.dart
+++ b/lib/features/profile/data/services/supabase_avatar_upload_service.dart
@@ -11,15 +11,10 @@ import 'package:deelmarkt/features/profile/domain/services/avatar_upload_service
 /// Path pattern: `avatars/<userId>/<timestamp>.<ext>`
 /// RLS enforces folder-level isolation per user.
 ///
-/// TODO(#148): `avatars` bucket + RLS must be provisioned by reso before
-/// this service is used in production. Until then, [MockAvatarUploadService]
-/// is used via the `useMockDataProvider` gate in [avatarUploadServiceProvider].
-///
-/// TODO(#148): Decide public vs private bucket before provisioning.
-/// `getPublicUrl()` returns a URL that 403s if the bucket is private (GDPR
-/// concern for user PII). Options: public bucket, signed URL with TTL, or
-/// Cloudinary pipeline like listings-images. Agree with reso before creating
-/// the bucket migration.
+/// Bucket is public — [getPublicUrl] resolves without a signed-URL TTL so
+/// avatars render on profile cards and listings. See migration
+/// `supabase/migrations/20260415150000_r05_avatars_bucket.sql` for the
+/// bucket + RLS definition.
 ///
 /// Reference: docs/screens/07-profile/01-own-profile.md
 class SupabaseAvatarUploadService implements AvatarUploadService {

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -113,6 +113,14 @@ public = false
 file_size_limit = "15MiB"
 allowed_mime_types = ["image/png", "image/jpeg", "image/webp", "image/heic"]
 
+# R-05b: Avatars bucket — public bucket for user profile pictures (Issue #148).
+# Public = true so getPublicUrl() works in SupabaseAvatarUploadService.
+# RLS enforces owner-only writes; reads are open (profiles visible to all).
+[storage.buckets.avatars]
+public = true
+file_size_limit = "15MiB"
+allowed_mime_types = ["image/png", "image/jpeg", "image/webp", "image/heic"]
+
 # GDPR data exports bucket — R-21
 # Private; user can only read their own exports. Signed URL valid 24h.
 [storage.buckets.user-data-exports]

--- a/supabase/migrations/20260415130000_r18_idin_cron.sql
+++ b/supabase/migrations/20260415130000_r18_idin_cron.sql
@@ -23,5 +23,5 @@ WHERE jobname = 'expire-idin-sessions';
 SELECT cron.schedule(
   'expire-idin-sessions',
   '0 * * * *',  -- every hour at :00
-  $$SELECT expire_stale_idin_sessions()$$
+  $$SELECT public.expire_stale_idin_sessions()$$
 );

--- a/supabase/migrations/20260415130000_r18_idin_cron.sql
+++ b/supabase/migrations/20260415130000_r18_idin_cron.sql
@@ -1,0 +1,27 @@
+-- R-18 ops: pg_cron schedule for iDIN session expiry cleanup.
+--
+-- The expire_stale_idin_sessions() function (defined in
+-- 20260410130000_r18_idin_sessions.sql) marks pending iDIN sessions as
+-- 'expired' once their expires_at has passed.  Sessions are 1-hour TTL,
+-- so an hourly cron at the top of the hour is sufficient.
+--
+-- Note: create_idin_session() already auto-expires stale sessions inline
+-- on each new initiation attempt, so this cron is a belt-and-suspenders
+-- cleanup — it ensures the table doesn't accumulate open 'pending' rows
+-- if the user never retries after a timeout.
+--
+-- Requires pg_cron extension (enabled by default on Supabase Pro).
+-- Idempotent: unschedule-then-reschedule pattern prevents duplicate jobs.
+
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- Idempotent: remove any existing job with this name before re-creating.
+SELECT cron.unschedule(jobid)
+FROM cron.job
+WHERE jobname = 'expire-idin-sessions';
+
+SELECT cron.schedule(
+  'expire-idin-sessions',
+  '0 * * * *',  -- every hour at :00
+  $$SELECT expire_stale_idin_sessions()$$
+);

--- a/supabase/migrations/20260415140000_r29_outbox_cron.sql
+++ b/supabase/migrations/20260415140000_r29_outbox_cron.sql
@@ -21,5 +21,5 @@ WHERE jobname = 'delete-processed-outbox';
 SELECT cron.schedule(
   'delete-processed-outbox',
   '0 3 * * *',  -- daily at 03:00 UTC
-  $$SELECT delete_processed_outbox_events(7)$$
+  $$SELECT public.delete_processed_outbox_events(7)$$
 );

--- a/supabase/migrations/20260415140000_r29_outbox_cron.sql
+++ b/supabase/migrations/20260415140000_r29_outbox_cron.sql
@@ -1,0 +1,25 @@
+-- R-29 ops: pg_cron schedule for search outbox cleanup.
+--
+-- The delete_processed_outbox_events() function (defined in
+-- 20260411100000_r29_search_outbox.sql) deletes rows from search_outbox
+-- that were already processed and are older than 7 days.  This prevents
+-- unbounded table growth and index bloat on idx_search_outbox_unprocessed.
+--
+-- Runs daily at 03:00 UTC — same window as the GDPR hard-delete cron to
+-- batch infrastructure maintenance together and avoid peak traffic hours.
+--
+-- Requires pg_cron extension (enabled by default on Supabase Pro).
+-- Idempotent: unschedule-then-reschedule pattern prevents duplicate jobs.
+
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- Idempotent: remove any existing job with this name before re-creating.
+SELECT cron.unschedule(jobid)
+FROM cron.job
+WHERE jobname = 'delete-processed-outbox';
+
+SELECT cron.schedule(
+  'delete-processed-outbox',
+  '0 3 * * *',  -- daily at 03:00 UTC
+  $$SELECT delete_processed_outbox_events(7)$$
+);

--- a/supabase/migrations/20260415150000_r05_avatars_bucket.sql
+++ b/supabase/migrations/20260415150000_r05_avatars_bucket.sql
@@ -28,11 +28,21 @@ VALUES (
   15728640,     -- 15 MiB
   ARRAY['image/png', 'image/jpeg', 'image/webp', 'image/heic']
 )
-ON CONFLICT (id) DO NOTHING;
+ON CONFLICT (id) DO UPDATE SET
+  public             = EXCLUDED.public,
+  file_size_limit    = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
 
 -- =============================================================================
 -- RLS policies for storage.objects (bucket: avatars)
 -- =============================================================================
+
+-- Drop existing policies first so the migration is idempotent on re-run
+-- (partial rollback, manual policy creation on staging, supabase db push edge cases).
+DROP POLICY IF EXISTS storage_avatars_insert ON storage.objects;
+DROP POLICY IF EXISTS storage_avatars_update ON storage.objects;
+DROP POLICY IF EXISTS storage_avatars_delete ON storage.objects;
+DROP POLICY IF EXISTS storage_avatars_select ON storage.objects;
 
 -- Authenticated users can upload avatars to their own folder only.
 CREATE POLICY storage_avatars_insert ON storage.objects
@@ -43,9 +53,15 @@ CREATE POLICY storage_avatars_insert ON storage.objects
   );
 
 -- Authenticated users can replace (upsert) their own avatar.
+-- WITH CHECK prevents path-rename attacks: even if USING passes (user owns
+-- the source row), the destination folder must also be the user's own.
 CREATE POLICY storage_avatars_update ON storage.objects
   FOR UPDATE TO authenticated
   USING (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  )
+  WITH CHECK (
     bucket_id = 'avatars'
     AND (storage.foldername(name))[1] = auth.uid()::text
   );

--- a/supabase/migrations/20260415150000_r05_avatars_bucket.sql
+++ b/supabase/migrations/20260415150000_r05_avatars_bucket.sql
@@ -1,0 +1,64 @@
+-- R-05b: Storage bucket for user avatar images (Issue #148).
+--
+-- The SupabaseAvatarUploadService uploads profile pictures here and
+-- returns a public URL via storage.getPublicUrl().  Bucket is therefore
+-- PUBLIC — avatars are displayed to all users on profile and listing cards.
+--
+-- Path convention: avatars/<userId>/<timestamp>.<ext>
+-- Matches SupabaseAvatarUploadService storagePath construction.
+--
+-- File limits:
+--   • Max size: 15 MiB (matches service-side maxFileSizeBytes)
+--   • Allowed MIME: PNG, JPEG, WebP, HEIC (matches _allowedExtensions)
+--
+-- RLS summary:
+--   • INSERT  — authenticated, own folder only (prevent overwriting others)
+--   • UPDATE  — authenticated, own folder only (upsert / replace)
+--   • DELETE  — authenticated, own folder only
+--   • SELECT  — public (bucket is public; policy is belt-and-suspenders)
+--
+-- Reference: lib/features/profile/data/services/supabase_avatar_upload_service.dart
+
+-- Create the bucket (idempotent via ON CONFLICT)
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'avatars',
+  'avatars',
+  true,         -- public: getPublicUrl() is used by the Flutter service
+  15728640,     -- 15 MiB
+  ARRAY['image/png', 'image/jpeg', 'image/webp', 'image/heic']
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- =============================================================================
+-- RLS policies for storage.objects (bucket: avatars)
+-- =============================================================================
+
+-- Authenticated users can upload avatars to their own folder only.
+CREATE POLICY storage_avatars_insert ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- Authenticated users can replace (upsert) their own avatar.
+CREATE POLICY storage_avatars_update ON storage.objects
+  FOR UPDATE TO authenticated
+  USING (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- Authenticated users can delete their own avatar (e.g. account reset).
+CREATE POLICY storage_avatars_delete ON storage.objects
+  FOR DELETE TO authenticated
+  USING (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- Anyone can read avatars — bucket is public, profiles are visible to all.
+CREATE POLICY storage_avatars_select ON storage.objects
+  FOR SELECT TO public
+  USING (bucket_id = 'avatars');

--- a/supabase/migrations/20260415160000_r18_r29_revoke_maintenance_functions.sql
+++ b/supabase/migrations/20260415160000_r18_r29_revoke_maintenance_functions.sql
@@ -1,0 +1,26 @@
+-- R-18 / R-29 hardening: revoke PostgREST RPC access on maintenance functions.
+--
+-- expire_stale_idin_sessions() and delete_processed_outbox_events() are
+-- SECURITY DEFINER maintenance jobs intended to be executed exclusively by
+-- the pg_cron background worker.  Without explicit REVOKE, they remain
+-- callable over PostgREST RPC by any authenticated (or anon) user, enabling
+-- denial-of-service vectors:
+--
+--   • SELECT public.expire_stale_idin_sessions()
+--       — forcibly expires other users' pending iDIN sessions.
+--
+--   • SELECT public.delete_processed_outbox_events(0)
+--       — deletes every processed row in search_outbox immediately,
+--         bypassing the 7-day retention window.
+--
+-- Matches the established convention for service-role-only functions in
+-- this codebase (e.g. gdpr_hard_delete_expired, get_overdue_dsa_reports,
+-- flag_message_scam).
+
+REVOKE ALL ON FUNCTION public.expire_stale_idin_sessions() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.expire_stale_idin_sessions() FROM anon;
+REVOKE ALL ON FUNCTION public.expire_stale_idin_sessions() FROM authenticated;
+
+REVOKE ALL ON FUNCTION public.delete_processed_outbox_events(INT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.delete_processed_outbox_events(INT) FROM anon;
+REVOKE ALL ON FUNCTION public.delete_processed_outbox_events(INT) FROM authenticated;


### PR DESCRIPTION
## Summary

- **R-18 cron** (`expire-idin-sessions`, hourly) — schedules `expire_stale_idin_sessions()` to clean up timed-out pending iDIN sessions. Belt-and-suspenders: `create_idin_session()` already auto-expires inline on retry, but this ensures no stale rows accumulate if a user never retries.
- **R-29 cron** (`delete-processed-outbox`, daily 03:00 UTC) — schedules `delete_processed_outbox_events(7)` to prune `search_outbox` rows processed >7 days ago, preventing unbounded table growth.
- **Avatars bucket** (`public=true`, 15 MiB, PNG/JPEG/WebP/HEIC) — creates the `avatars` Supabase Storage bucket with 4 RLS policies (owner INSERT/UPDATE/DELETE, public SELECT). Bucket is public so `SupabaseAvatarUploadService.getPublicUrl()` returns a working URL.
- **config.toml** — adds `[storage.buckets.avatars]` entry.

## What was already done (not in this PR)

Issue #144 config gaps were already resolved in previous PRs:
- `[functions.initiate-idin]`, `[functions.export-user-data]`, `[functions.process-search-outbox]` — all in `config.toml` ✅
- `[storage.buckets.user-data-exports]` + migration — exists ✅

Only the pg_cron schedules were missing.

## Vault checklist (ops — cannot be automated)

- [ ] Verify `IDIN_*` keys exist in staging Supabase Vault
- [ ] Verify Upstash Redis `REDIS_URL` / `REDIS_TOKEN` exist in staging Vault

## Test plan

- [ ] `supabase db reset` applies all 3 new migrations without error
- [ ] `SELECT * FROM cron.job WHERE jobname IN ('expire-idin-sessions', 'delete-processed-outbox');` returns 2 rows on staging
- [ ] Upload an avatar via the app → verify public URL returns 200
- [ ] Attempt to upload to another user's folder → verify 403 (RLS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)