### PR TITLE
docs(chat): add dark-mode chat thread design reference (closes #164)

### DIFF
--- a/docs/PLAN-p43-dark-mode-chat-golden.md
+++ b/docs/PLAN-p43-dark-mode-chat-golden.md
@@ -1,0 +1,215 @@
+# PLAN — P-43 Dark Mode Chat Thread Design Handoff + Golden Regeneration
+
+> **Owner:** pizmam (`[P]`) — Frontend / Design
+> **Epic:** E07 Infrastructure (launch readiness) · follow-up to E04 Messaging
+> **Branch:** `feature/pizmam-P43-dark-mode-chat-golden` (created from `origin/dev`)
+> **Parent PR (merged):** [#161](https://github.com/deelmarkt-org/app/pull/161) — ASO pipeline
+> **Closes:** issue [#164](https://github.com/deelmarkt-org/app/issues/164) — Design handoff: dark mode chat thread golden PNG
+> **Tier:** **Medium** (3–10 files across design references + goldens + docs)
+> **Estimate:** 0.5 developer-day (no production `lib/` changes)
+> **Status:** Planning → awaiting approval
+> **Produced via:** `.agent/workflows/plan.md` v2.2.0 (Specialist Synthesis + rule consultation)
+
+---
+
+## 1 · Context & Current-State Audit
+
+### What merged (PR #161)
+- 240 golden screenshots generated via `test/screenshots/drivers/` (10 hero screens × 2 locales × 2 themes × 6 devices).
+- Dark-mode chat thread goldens **already exist** (24 files, e.g. [chat_thread_nl_NL_dark_ios_67.png](test/screenshots/drivers/goldens/chat_thread_nl_NL_dark_ios_67.png)) — captured against the running `ChatThreadScreen` widget in dark mode.
+- Pixel diffing runs **only on macOS CI** ([screenshot_driver.dart:170](test/screenshots/_support/screenshot_driver.dart:170)); Linux/Windows pumps the widget but skips `expectLater(matchesGoldenFile)`.
+
+### The blocker (issue #164)
+- `docs/screens/06-chat/designs/` has **3 chat-thread design variants**:
+  - `chat_thread_mobile_light/` ✅ (layout + copy source of truth)
+  - `chat_thread_mobile_dark_scam_alert/` ✅ (dark base + red scam banner)
+  - `chat_thread_desktop_expanded/` ✅
+  - `chat_thread_mobile_dark/` ❌ **missing** — no "normal" dark variant design reference
+- Consequence: the committed dark-mode goldens are a **snapshot of what the widget renders today**, with no design PNG to diff against. Any unintended dark-mode regression (wrong bubble tint, contrast drop on timestamps, etc.) would be invisible to reviewers.
+
+### Why this matters (legal / conversion)
+- **Dark mode is a CLAUDE.md §10 accessibility gate** — reduced-motion / dark-mode support is declared in spec [`02-chat-thread.md:16`](docs/screens/06-chat/02-chat-thread.md:16) as **Required**.
+- **App Store Review guideline 4.0** expects parity between marketed screenshots and shipped UI. Screenshot regressions in the hero set delay submission.
+- The existing `mahmutkaya` approving review on PR #161 explicitly tracked this as "M9 — tracked in issue #164, needs designer handoff noted in sprint plan." Shipping the reference closes the review loop.
+
+### What is NOT in scope (guarded by scope filter)
+- No changes to `ChatThreadScreen` widget or any `lib/` production code.
+- No changes to l10n copy, design tokens, or theme.
+- No changes to Fastlane / ASO metadata (guarded by CLAUDE.md §13 — marketing assets require explicit human approval).
+- No regeneration of non-dark / non-chat_thread goldens.
+- Scam-alert variant stays as-is; we are filling the gap for the "normal" dark variant only.
+
+---
+
+## 2 · Rule Consultation (mandatory — per plan.md step 3)
+
+Extracted from CLAUDE.md and `~/.claude/rules/**`:
+
+| Mandate | Source | Applies here as |
+|:--------|:-------|:----------------|
+| UI tasks require spec + design-reference verification block | CLAUDE.md §7.1 step 5 | Plan includes the `### Design reference` block (§7 below) |
+| Design tokens only — no raw hex | CLAUDE.md §3.3, §4.3 | Derived dark-mode reference must only use `DeelmarktColors.dark*` values; HTML source uses the same MD3 palette as existing dark design |
+| Marketing asset guardrail | CLAUDE.md §13 | `docs/screens/**` is NOT a marketing asset (marketing = `fastlane/metadata/**` and `docs/marketing/aso/**`) → safe to edit without §13 human approval, but still needs PR review |
+| Pre-commit quality gates must pass | CLAUDE.md §8 | `flutter analyze`, `check_quality.dart`, screenshot PNG audit (`check_screenshots.sh`) all must stay green |
+| 70%+ test coverage floor | CLAUDE.md §6.1 | N/A — no `lib/` code touched; coverage unaffected |
+| Accessibility (WCAG 2.2 AA, EAA) | CLAUDE.md §10, `~/.claude/rules/security.md` | Dark-mode reference must maintain 4.5:1 contrast on message text, 3:1 on large text — verified by sampling |
+| Immutability / file length / naming | `~/.claude/rules/coding-style.md` | N/A — no Dart changes |
+| Design handoff protocol | `docs/screens/06-chat/02-chat-thread.md` | Dark mode listed as "Required" variation (line 16 + Design Prompt line 72) |
+
+**Rejection triggers evaluated (quality-gate.md):** none fire. This is a design-deliverable close-out, not a new feature — no market research required.
+
+---
+
+## 3 · Specialist Synthesis (per planningMandates)
+
+### 3.1 `security-reviewer` — Threat Assessment
+| Threat | Mitigation | Test |
+|:-------|:-----------|:-----|
+| **PII leak via design reference** (real avatar, real Dutch phone number / address rendered into the PNG) | Reference HTML uses the **same fictitious persona** as the light variant: "Jan de Vries", Canyon Speedmax, `@example.invalid` seed data anchored in [`test/screenshots/_support/seed_data.dart`](test/screenshots/_support/seed_data.dart) | Manual inspection of generated PNG; existing `scripts/check_screenshots.sh` OCR PII scan covers the `goldens/` copy |
+| **Tracking-pixel or remote asset in HTML** | Use local font/CSS only; no `<script src="http…">` to external trackers; match existing `chat_thread_mobile_light/code.html` structure | `grep -n "http://\|https://" docs/screens/06-chat/designs/chat_thread_mobile_dark/code.html` → allow-list: Google Fonts + Material Symbols CDNs only (same as existing) |
+| **Secret leak in committed PNG metadata** | Strip EXIF / XMP from generated PNG via `pngcrush`/`exiftool` before commit | File size + metadata check (already in `check_screenshots.sh`) |
+
+### 3.2 `tdd-guide` — Test & Verification Strategy
+No new `lib/` code → no new unit / widget tests. Verification is **visual + automated asset-lint**:
+
+| Verification | Command | Pass Criterion |
+|:-------------|:--------|:---------------|
+| Design PNG present | `ls docs/screens/06-chat/designs/chat_thread_mobile_dark/screen.png` | Exists |
+| Design HTML valid | Open in browser; visually matches layout spec §02-chat-thread.md §1–6 | No layout break; matches existing light layout modulo palette |
+| Golden regenerated (macOS CI) | `screenshots.yml` workflow on PR runs `flutter test --update-goldens test/screenshots/drivers/chat_thread_screenshot_test.dart` → auto-commits | All 24 dark-variant PNGs diff cleanly (or auto-updated by CI) |
+| Screenshot count stable | `bash scripts/check_screenshots.sh` | 240 total PNGs maintained |
+| SCREEN-MAP variant count accurate | `docs/screens/SCREEN-MAP.md:30` currently says `(6)` for `chat_*` — add new row if variant count changes | Count matches `ls docs/screens/06-chat/designs/chat_thread_*` |
+| No accessibility regression | Dark-mode contrast check on reference tokens | All message text ≥ 4.5:1, chips ≥ 3:1 against surface |
+
+### 3.3 `architect` — Architecture Impact
+- **No production architecture change.** All touches are in `docs/` + possibly `test/screenshots/drivers/goldens/` (CI auto-commits goldens anyway).
+- **Design-system invariant preserved** — reference HTML MUST mirror the dark-mode MD3 tokens already used in `chat_thread_mobile_dark_scam_alert/code.html` (authoritative source).
+- **No new dependencies.** HTML is self-contained; PNG is derived from rendering + screenshotting that HTML at 1290×2796 (iOS 6.7") — matches existing design PNG conventions.
+- **Review gate stays the same** — PR still requires belengaz or reso approval per sprint plan §Conflict Prevention.
+
+---
+
+## 4 · Deliverables (ordered by dependency)
+
+### 4.1 Design Reference (primary)
+| File | Action | Source |
+|:-----|:-------|:-------|
+| `docs/screens/06-chat/designs/chat_thread_mobile_dark/code.html` | **Create** | Derive from `chat_thread_mobile_dark_scam_alert/code.html` (already dark-palette correct) **minus** the scam-alert `<div class="bg-error-container ..."` banner (§176-189 of that file). Visually equivalent to the light variant at [`chat_thread_mobile_light/code.html`](docs/screens/06-chat/designs/chat_thread_mobile_light/code.html) but with dark tokens. |
+| `docs/screens/06-chat/designs/chat_thread_mobile_dark/screen.png` | **Create** | Rendered PNG of the above HTML at **1290×2796 logical** (iOS 6.7") — matches the dimension convention of existing dark-mode PNG references. If the user has already attached a designer handoff PNG (1290×2796), use that as-is instead of rendering. |
+
+### 4.2 Sprint Plan + Screen Map Updates
+| File | Change |
+|:-----|:-------|
+| `docs/SPRINT-PLAN.md:287-288` | Flip `[ ] P-43 …🔄 PR #161 open` → `[x] P-43 … ✅ PR #161` and remove the `⏳ Blocked on designer handoff` sub-bullet (replace with `✅ Dark-mode chat thread design added — issue #164`) |
+| `docs/screens/SCREEN-MAP.md:30` | Confirm variant count for `chat_*` (was "(6)") — after addition will become "(7)" if we count the new normal-dark folder separately, or stay "(6)" if we count folders (3 chat_* + 4 messages_* + 4 scam_*). Read current formula and update only if drift. |
+
+### 4.3 Golden Baseline (secondary — auto-handled by CI)
+The existing `screenshots.yml` workflow auto-commits regenerated goldens on PR push via the `github-actions[bot]` step introduced in PR #161 commit `bbd71fe`. We do **not** regenerate locally (Windows vs macOS font drift would produce flaky baselines — same root cause as the H-1 CI fix on PR #161).
+
+### 4.4 Issue & PR Close-Out
+| Action | Target |
+|:-------|:-------|
+| Close issue #164 with resolution comment referencing commit SHA + new design PNG path | issue #164 |
+| Update `docs/PLAN-p43-aso.md` § retrospective (if it has a follow-ups section) | — |
+| Open PR against `dev` with full test plan + screenshots | new PR |
+
+---
+
+## 5 · Implementation Steps (verifiable — per plan.md Output Template)
+
+| # | Task | File(s) | Verify |
+|:--|:-----|:--------|:-------|
+| 1 | Copy & adapt `chat_thread_mobile_dark_scam_alert/code.html` — remove scam-alert banner block; keep header / listing card / messages / offer card / input bar identical | `docs/screens/06-chat/designs/chat_thread_mobile_dark/code.html` | `diff` shows only removed `<div>` for scam banner; palette tokens unchanged; opens in browser without layout shift |
+| 2 | Validate HTML tokens match dark theme — check that the `tailwind.config` colours align with existing dark reference (note: scam_alert HTML has a `"background": "#121212"` / `"on-surface": "#f2f2f2"` dark override — preserve these) | same file | `grep '"background"\|"on-surface"' ...` → `#121212` / `#f2f2f2` |
+| 3 | Generate `screen.png` at 1290×2796 — either use attached designer PNG (if the image user sent is the dark reference) **or** render HTML via headless Chrome / screenshot tool at that resolution, strip EXIF | `docs/screens/06-chat/designs/chat_thread_mobile_dark/screen.png` | `identify screen.png` → `1290x2796`; file size < 2 MB; no EXIF |
+| 4 | Update [`docs/SPRINT-PLAN.md:287-288`](docs/SPRINT-PLAN.md:287) — mark P-43 done, remove designer-handoff blocker bullet | `docs/SPRINT-PLAN.md` | Only two lines changed; `dart run scripts/check_quality.dart` green |
+| 5 | Check `docs/screens/SCREEN-MAP.md` variant count drift for chat_* row | `docs/screens/SCREEN-MAP.md` | Count matches `ls docs/screens/06-chat/designs/chat_thread_*` |
+| 6 | Run local quality gates | — | `dart run scripts/check_quality.dart` ✓ · `bash scripts/check_screenshots.sh` ✓ · `flutter analyze --no-pub` ✓ (nothing to analyze in `lib/`) |
+| 7 | Commit with `docs(chat): add dark mode chat thread design reference (closes #164)` | — | Pre-commit hooks green (format, analyze, quality, coverage — last is N/A, no `lib/` diff) |
+| 8 | Push; CI runs `screenshots.yml` → auto-commits any baseline drift on the branch | — | 8/8 CI checks green on PR |
+| 9 | Open PR `feature/pizmam-P43-dark-mode-chat-golden` → `dev` using `/pr` workflow; request review from belengaz or reso | — | PR created with full test plan referencing issue #164 |
+| 10 | After merge: close issue #164 with resolution comment pointing to the PR + design PNG | — | Issue #164 state = CLOSED |
+
+---
+
+## 6 · Risks & Mitigations
+
+| # | Risk | Likelihood | Impact | Mitigation |
+|:-:|:-----|:----------|:-------|:-----------|
+| R1 | The image the user just attached is **not** the designer handoff (could be a test golden, a reference from the app, or unrelated) | Medium | Low | Plan step 3 has a fork: use attached PNG IF confirmed by user, else render from the derived HTML (no blocker) |
+| R2 | Rendered HTML PNG differs visually from the actual Flutter golden (font hinting, anti-aliasing) | Low | Low | This is expected — the design PNG is a **reference for reviewers**, not a pixel-exact source of truth for the golden. The golden stays deterministic via the Flutter test driver. |
+| R3 | CI auto-commits a baseline drift that conflicts with an in-flight parallel PR (e.g. PR #168 a11y follow-up) | Low | Medium | Chat-thread goldens are not touched by PR #168 (which is a11y-focused on other screens); rebase strategy if conflict appears. |
+| R4 | SCREEN-MAP.md count mis-match triggers `check_quality` regression | Very Low | Low | Step 5 explicitly audits; fix inline before commit. |
+| R5 | HTML reference renders incorrectly in non-Chromium browsers used by reviewers (Safari, Firefox) | Low | Very Low | Use the **exact** CDN + Tailwind config that the existing light/dark references use — proven to render consistently. |
+| R6 | Dark-mode HTML tokens drift from actual `DeelmarktColors.dark*` values | Low | Medium | The scam_alert HTML already uses `#121212`/`#f2f2f2` — matches `DeelmarktColors.darkScaffold` / `DeelmarktColors.darkOnSurface` (verified [colors.dart:59-65](lib/core/design_system/colors.dart:59)). Re-use those values 1:1. |
+
+---
+
+## 7 · Pre-Implementation Verification (CLAUDE.md §7.1 mandatory)
+
+### Schema (N/A)
+No Supabase queries, no Edge Function, no migration.
+
+### Sibling conventions (design reference folder)
+- All sibling variants under `docs/screens/06-chat/designs/` follow `<variant_name>/{code.html,screen.png}` convention ✓
+- HTML uses Tailwind CDN + Google Fonts + Material Symbols; dark variants add `class="dark"` to `<html>` ✓
+- PNG dimensions: mobile variants are 1290×2796 (iOS 6.7") or 375×812 depending on iPhone variant — will match the existing `chat_thread_mobile_dark_scam_alert/screen.png` dimension precisely.
+
+### Epic acceptance criteria audit (E04 Messaging + issue #164)
+| Criterion | Coverage |
+|:----------|:--------:|
+| `chat_thread_mobile_dark.png` delivered under `docs/screens/06-chat/designs/` | Fully (step 3) |
+| Golden regenerated via `flutter test --update-goldens …/chat_thread_screenshot_test.dart` | Fully (step 8 — CI auto-commit path) |
+| `docs/screens/SCREEN-MAP.md` variant count updated if new design adds a variant | Fully (step 5) |
+
+### Existing UI/logic scan
+- `ChatThreadScreen` widget [chat_thread_screenshot_test.dart:27](test/screenshots/drivers/chat_thread_screenshot_test.dart:27) → no change needed; widget already renders dark mode correctly.
+- Spec [`docs/screens/06-chat/02-chat-thread.md:16`](docs/screens/06-chat/02-chat-thread.md:16) → "Dark mode: Required" — confirmed.
+- `DeelmarktTheme.dark` → no change needed; P-47 (PR #157) already shipped dark mode.
+- Goldens under `test/screenshots/drivers/goldens/chat_thread_*_dark_*.png` (24 files) → stay as authoritative implementation snapshot.
+
+### Design reference (CLAUDE.md §7.1 UI-task format)
+- **Spec:** [`docs/screens/06-chat/02-chat-thread.md`](docs/screens/06-chat/02-chat-thread.md) ✓ (layout §1–6, l10n §78–92, dark-mode requirement line 16)
+- **Designs checked:**
+  - `chat_thread_mobile_light/screen.png` ✓ (layout source of truth — seen; Dutch copy, Canyon Speedmax €149, offer card)
+  - `chat_thread_mobile_dark_scam_alert/screen.png` ✓ (dark palette source of truth — seen; same layout + red scam banner)
+  - `chat_thread_desktop_expanded/` ✓ (sanity check for responsive parity)
+- **All l10n keys from spec present in both locale files** — confirmed via PR #161 merged state (check_aso / check_quality both green on merge).
+
+---
+
+## 8 · Agent Assignments (single-domain)
+| Task | Role | Domain |
+|:-----|:-----|:-------|
+| Design reference creation + docs updates | pizmam (self, Frontend/Design) | `docs/screens/` |
+| PR open + CI gate shepherding | pizmam | `/pr` workflow |
+| Review approval | belengaz OR reso | per sprint plan §Conflict Prevention |
+
+---
+
+## 9 · Completion Criteria
+
+- [ ] `docs/screens/06-chat/designs/chat_thread_mobile_dark/code.html` exists and renders cleanly in Chromium
+- [ ] `docs/screens/06-chat/designs/chat_thread_mobile_dark/screen.png` exists at 1290×2796, no EXIF, <2MB
+- [ ] `docs/SPRINT-PLAN.md` — P-43 marked done, designer-handoff blocker removed
+- [ ] `docs/screens/SCREEN-MAP.md` — variant count accurate
+- [ ] Local gates green: `check_quality.dart`, `check_screenshots.sh`, `flutter analyze`
+- [ ] PR opened to `dev` with complete test plan and design PNG attached
+- [ ] All 8 CI checks pass (Format & Analyze, CodeQL, ASO Copy Lint, Screenshot Audit, Regenerate & Diff Screenshots, Analyze JS/TS, Test & Coverage, Security Scan)
+- [ ] Reviewer approval from belengaz or reso
+- [ ] PR merged to `dev`
+- [ ] Issue #164 closed with resolution comment referencing merged commit
+
+---
+
+## 10 · Next Workflow Steps
+
+After user approval:
+1. `/implement` or direct execution of §5 steps 1→10
+2. Post-implementation: `/plan-complete` hook logs retrospective to `.agent/contexts/plan-quality-log.md`
+3. Sprint plan update triggers no additional cascading tasks — P-43 closes fully.
+
+---
+
+_Generated via `.agent/workflows/plan.md` v2.2.0_
+_Validated against: CLAUDE.md §7.1, §8, §10, §13 · `.agent/workflows/quality-gate.md` (rejection triggers: none fired) · Specialist Synthesis Protocol (security-reviewer, tdd-guide, architect)_

--- a/docs/SPRINT-PLAN.md
+++ b/docs/SPRINT-PLAN.md
@@ -284,8 +284,7 @@ The agent will:
 - [x] `P-40` Admin moderation panel — Phase A ✅ PR #110
 - [x] `P-41` Seller/buyer mode home toggle — dashboard adapts ✅ PR #107
 - [ ] `P-42` Accessibility final audit — all screens WCAG 2.2 AA 🔄 PR #155 open (EAA blockers: issue #156)
-- [ ] `P-43` App Store screenshots + ASO metadata — both stores 🔄 PR #161 open (feature/pizmam-P43-aso)
-  - ⏳ Blocked on designer handoff: dark mode chat thread PNG missing — issue #164
+- [x] `P-43` App Store screenshots + ASO metadata — both stores ✅ PR #161 (dark-mode chat thread design added as follow-up — closes issue #164)
 - [x] `P-44` Social login (Google + Apple Sign-In) — native flow (iOS ASAuth + Android google_sign_in) + web redirect, `user_profiles` auto-trigger, Apple HIG button ✅ PR #159
 - [x] `P-45` Flutter Web performance budget & CanvasKit strategy ✅ PR #14
 - [x] `P-47` Dark mode implementation & validation ✅ PR #157

--- a/docs/screens/06-chat/designs/chat_thread_mobile_dark/code.html
+++ b/docs/screens/06-chat/designs/chat_thread_mobile_dark/code.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+
+<html class="dark" lang="nl"><head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+<style>
+        body { font-family: 'Plus Jakarta Sans', sans-serif; }
+        .material-symbols-outlined {
+            font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+        }
+        .offer-gradient {
+            background: linear-gradient(135deg, #006b24 0%, #008730 100%);
+        }
+        .scrollbar-hide::-webkit-scrollbar {
+            display: none;
+        }
+    </style>
+<script id="tailwind-config">
+        tailwind.config = {
+          darkMode: "class",
+          theme: {
+            extend: {
+              colors: {
+                "secondary-fixed": "#d0e4ff",
+                "on-error-container": "#93000a",
+                "on-primary-fixed-variant": "#842500",
+                "surface-container-lowest": "#ffffff",
+                "secondary-fixed-dim": "#9fcafc",
+                "primary-fixed-dim": "#ffb59e",
+                "error": "#ba1a1a",
+                "tertiary-fixed-dim": "#65df75",
+                "surface-bright": "#fcf9f8",
+                "surface-container-low": "#f6f3f2",
+                "on-secondary": "#ffffff",
+                "on-primary-container": "#fffbff",
+                "background": "#121212",
+                "on-surface": "#f2f2f2",
+                "on-surface-variant": "#c4c4c4",
+                "on-primary": "#ffffff",
+                "on-secondary-fixed": "#001d35",
+                "on-secondary-container": "#285782",
+                "on-error": "#ffffff",
+                "outline-variant": "#e2bfb4",
+                "secondary-container": "#a1cdff",
+                "on-tertiary": "#ffffff",
+                "inverse-on-surface": "#f3f0ef",
+                "surface-container-highest": "#e5e2e1",
+                "tertiary-container": "#008730",
+                "on-primary-fixed": "#3a0b00",
+                "secondary": "#34618d",
+                "inverse-surface": "#313030",
+                "on-tertiary-container": "#f7fff2",
+                "tertiary": "#006b24",
+                "inverse-primary": "#ffb59e",
+                "tertiary-fixed": "#82fc8e",
+                "surface-container": "#f0edec",
+                "surface": "#fcf9f8",
+                "primary": "#FF7A4D",
+                "on-tertiary-fixed-variant": "#00531a",
+                "surface-dim": "#dcd9d9",
+                "error-container": "#ffdad6",
+                "primary-container": "#d1430a",
+                "on-tertiary-fixed": "#002106",
+                "on-background": "#1c1b1b",
+                "surface-variant": "#e5e2e1",
+                "primary-fixed": "#ffdbd0",
+                "surface-tint": "#ad3300",
+                "surface-container-high": "#ebe7e7",
+                "outline": "#8e7067",
+                "on-secondary-fixed-variant": "#164974"
+              },
+              fontFamily: {
+                "headline": ["Plus Jakarta Sans"],
+                "body": ["Plus Jakarta Sans"],
+                "label": ["Plus Jakarta Sans"]
+              },
+              borderRadius: {"DEFAULT": "0.25rem", "lg": "0.5rem", "xl": "0.75rem", "full": "9999px"},
+            },
+          },
+        }
+    </script>
+<style>
+    body {
+      min-height: max(884px, 100dvh);
+    }
+  </style>
+  </head>
+<body class="bg-[#121212] flex items-center justify-center min-h-screen p-0 md:p-8 overflow-hidden">
+<!-- iPhone 15 Pro Frame -->
+<div class="relative w-full max-w-[430px] h-[932px] bg-[#121212] rounded-[55px] border-[12px] border-[#313030] shadow-[0_0_80px_rgba(0,0,0,0.8)] overflow-hidden flex flex-col">
+<!-- Dynamic Island Area -->
+<div class="absolute top-0 left-1/2 -translate-x-1/2 w-32 h-8 bg-black rounded-b-3xl z-[100]"></div>
+<!-- TopAppBar -->
+<header class="bg-[#121212]/95 backdrop-blur-xl fixed top-0 w-full z-50 pt-10 pb-4 px-6 flex justify-between items-center transition-all duration-200">
+<div class="flex items-center gap-4">
+<button class="text-zinc-400 hover:text-white transition-colors" aria-label="Back">
+<span class="material-symbols-outlined text-2xl">arrow_back</span>
+</button>
+<div class="relative">
+<img alt="Jan de Vries avatar showing online status" class="w-8 h-8 rounded-full object-cover grayscale-[0.2]" src="https://lh3.googleusercontent.com/aida-public/AB6AXuAZU-Wx9ZqPuaCpzvrPSaa4R5R8MxKJKi7HpX8Wdj8pTRX8TkfU1oZ-Tcs-wOYabKSPKUvON7vAkTsDlol1i3kIQAWweihahtLMBzcNWucgVqkUTEactrxIaDFmt4cGC-4IYUg3isLl4s3lktlmZXmyMTvGhBceew_Sa92gibOXV90iOQEgrVwEua0MsrCnYhiMrkQH_jHz10Q9G--4OmPjAfvXhNRPZW8KP8MGNVj2Te3gtOhcgwYdYn8m8XUbWnWKcsMq_Gp1QCx4"/>
+<div class="absolute bottom-0 right-0 w-2.5 h-2.5 bg-green-500 border-2 border-[#121212] rounded-full shadow-lg"></div>
+</div>
+<div class="flex flex-col -gap-1">
+<h1 class="text-white font-bold text-sm tracking-tight">Jan de Vries</h1>
+<span class="text-[10px] text-green-500 font-medium tracking-wide uppercase">Online</span>
+</div>
+</div>
+<div class="flex gap-2">
+<span class="material-symbols-outlined text-zinc-400 hover:text-white cursor-pointer">videocam</span>
+<span class="material-symbols-outlined text-zinc-400 hover:text-white cursor-pointer">call</span>
+<span class="material-symbols-outlined text-zinc-400 hover:text-white cursor-pointer">more_vert</span>
+</div>
+</header>
+<!-- Main Content Canvas -->
+<main class="flex-1 overflow-y-auto pt-24 pb-40 scrollbar-hide px-4 flex flex-col gap-6">
+<!-- Listing Context Card -->
+<div class="bg-zinc-900/40 rounded-2xl p-3 flex items-center gap-4 border border-zinc-800/50 backdrop-blur-sm">
+<img alt="Canyon Speedmax thumbnail" class="w-14 h-14 rounded-xl object-cover shadow-inner" src="https://lh3.googleusercontent.com/aida-public/AB6AXuD-6IssqfZ8TzxpH0Ty-Hbc7zr8A1dgRE-1iKDQ2em5Rj0Zi7cohN4ZTF10GBbZcN8CzjxmcJDNwyLiXJ3KVf6oG1DWp_l51o-xm_hixvKwCFlOpzpkDXhdgz42Su5bZg3c1T35eU3lORvf6rMp0MaojJZZs6Cs1RsB0sO1oCJEmzW42CQJO-YgzA7uZOJspcNOjzjff_LRNWDLl3NYDA5GSzvS9X11tAWkkWPVXTKCPP5X0PXKLfXTN2BYAah1JYo2US5qNGxt9CVO"/>
+<div class="flex flex-col flex-1">
+<div class="flex justify-between items-start">
+<span class="text-white font-semibold text-sm">Canyon Speedmax</span>
+<span class="bg-zinc-800 text-zinc-400 text-[10px] px-2 py-0.5 rounded-full uppercase font-bold tracking-widest">Te koop</span>
+</div>
+<span class="text-[#9fcafc] font-bold text-lg leading-tight">€ 149,00</span>
+</div>
+</div>
+<!-- Thread Date Separator -->
+<div class="flex items-center justify-center my-2">
+<div class="h-[1px] flex-1 bg-zinc-800"></div>
+<span class="px-4 text-[11px] text-zinc-500 font-bold uppercase tracking-[0.2em]">Vandaag</span>
+<div class="h-[1px] flex-1 bg-zinc-800"></div>
+</div>
+<!-- Chat Messages -->
+<!-- Seller Message (Left) -->
+<div class="flex flex-col gap-1 items-start max-w-[85%]">
+<div class="bg-[#2a2a2a] text-zinc-100 p-4 rounded-2xl rounded-tl-none text-sm leading-relaxed shadow-sm">
+                    Hoi! Is de fiets nog beschikbaar?
+                </div>
+<span class="text-[10px] text-zinc-600 font-medium ml-1">10:42</span>
+</div>
+<!-- Buyer Message (Right) -->
+<div class="flex flex-col gap-1 items-end max-w-[85%] self-end">
+<div class="bg-[#d1430a] text-white p-4 rounded-2xl rounded-tr-none text-sm leading-relaxed shadow-[0_4px_12px_rgba(169,50,0,0.3)]">
+                    Ja, nog beschikbaar! Wanneer kun je langskomen?
+                </div>
+<div class="flex items-center gap-1 mr-1">
+<span class="text-[10px] text-zinc-600 font-medium">10:45</span>
+<span class="material-symbols-outlined text-[12px] text-primary" style="font-variation-settings: 'FILL' 1;">done_all</span>
+</div>
+</div>
+<!-- Offer Card -->
+<div class="flex flex-col gap-1 items-start w-full">
+<div class="w-full bg-zinc-900 border border-zinc-800 rounded-[24px] p-5 shadow-2xl">
+<div class="flex items-center justify-between mb-6">
+<div class="flex items-center gap-3">
+<div class="w-10 h-10 rounded-full bg-tertiary/20 flex items-center justify-center text-tertiary">
+<span class="material-symbols-outlined">payments</span>
+</div>
+<div>
+<h3 class="text-zinc-400 text-[10px] uppercase font-bold tracking-widest">Nieuw Bod</h3>
+<p class="text-white text-2xl font-black">€ 120,00</p>
+</div>
+</div>
+</div>
+<div class="flex flex-col gap-3">
+<button class="w-full h-12 rounded-xl offer-gradient text-white font-bold text-sm tracking-wide shadow-lg active:scale-95 transition-transform duration-200">
+                            Accepteren
+                        </button>
+<button class="w-full h-12 rounded-xl border border-zinc-700 text-zinc-300 font-bold text-sm tracking-wide hover:bg-zinc-800 active:scale-95 transition-all">
+                            Afwijzen
+                        </button>
+</div>
+</div>
+<span class="text-[10px] text-zinc-600 font-medium ml-1">10:50</span>
+</div>
+</main>
+<!-- Fixed Bottom Interaction Area -->
+<footer class="fixed bottom-0 w-full bg-[#121212] z-[60] pb-10 px-4 pt-3">
+<!-- Input Bar -->
+<div class="flex items-center gap-3 bg-zinc-900/80 backdrop-blur-md p-2 pl-4 rounded-[28px] border border-zinc-800/50">
+<button class="text-zinc-400 hover:text-white transition-colors" aria-label="Camera">
+<span class="material-symbols-outlined">photo_camera</span>
+</button>
+<div class="h-6 w-[1px] bg-zinc-800"></div>
+<div class="flex-1 relative flex items-center">
+<input class="w-full bg-transparent border-none text-sm text-zinc-200 focus:ring-0 placeholder-zinc-600 py-2" placeholder="Typ een bericht..." type="text"/>
+<button class="bg-zinc-800 hover:bg-zinc-700 text-zinc-300 px-3 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider mr-2 transition-colors">
+                        Bod
+                    </button>
+</div>
+<button class="w-10 h-10 rounded-full bg-[#d1430a] flex items-center justify-center text-white shadow-[0_4px_12px_rgba(169,50,0,0.4)] active:scale-90 transition-transform" aria-label="Send">
+<span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1;">send</span>
+</button>
+</div>
+</footer>
+<!-- iPhone Home Indicator -->
+<div class="absolute bottom-1.5 left-1/2 -translate-x-1/2 w-32 h-1 bg-white/20 rounded-full z-[100]"></div>
+</div>
+</body></html>

--- a/docs/screens/06-chat/designs/chat_thread_mobile_dark/code.html
+++ b/docs/screens/06-chat/designs/chat_thread_mobile_dark/code.html
@@ -88,22 +88,22 @@
     }
   </style>
   </head>
-<body class="bg-[#121212] flex items-center justify-center min-h-screen p-0 md:p-8 overflow-hidden">
+<body class="bg-background flex items-center justify-center min-h-screen p-0 md:p-8 overflow-hidden">
 <!-- iPhone 15 Pro Frame -->
-<div class="relative w-full max-w-[430px] h-[932px] bg-[#121212] rounded-[55px] border-[12px] border-[#313030] shadow-[0_0_80px_rgba(0,0,0,0.8)] overflow-hidden flex flex-col">
+<div class="relative w-full max-w-[430px] h-[932px] bg-background rounded-[55px] border-[12px] border-inverse-surface shadow-[0_0_80px_rgba(0,0,0,0.8)] overflow-hidden flex flex-col">
 <!-- Dynamic Island Area -->
 <div class="absolute top-0 left-1/2 -translate-x-1/2 w-32 h-8 bg-black rounded-b-3xl z-[100]"></div>
 <!-- TopAppBar -->
-<header class="bg-[#121212]/95 backdrop-blur-xl fixed top-0 w-full z-50 pt-10 pb-4 px-6 flex justify-between items-center transition-all duration-200">
+<header class="bg-background/95 backdrop-blur-xl fixed top-0 w-full z-50 pt-10 pb-4 px-6 flex justify-between items-center transition-all duration-200">
 <div class="flex items-center gap-4">
 <button class="text-zinc-400 hover:text-white transition-colors" aria-label="Back">
 <span class="material-symbols-outlined text-2xl">arrow_back</span>
 </button>
 <div class="relative">
 <img alt="Jan de Vries avatar showing online status" class="w-8 h-8 rounded-full object-cover grayscale-[0.2]" src="https://lh3.googleusercontent.com/aida-public/AB6AXuAZU-Wx9ZqPuaCpzvrPSaa4R5R8MxKJKi7HpX8Wdj8pTRX8TkfU1oZ-Tcs-wOYabKSPKUvON7vAkTsDlol1i3kIQAWweihahtLMBzcNWucgVqkUTEactrxIaDFmt4cGC-4IYUg3isLl4s3lktlmZXmyMTvGhBceew_Sa92gibOXV90iOQEgrVwEua0MsrCnYhiMrkQH_jHz10Q9G--4OmPjAfvXhNRPZW8KP8MGNVj2Te3gtOhcgwYdYn8m8XUbWnWKcsMq_Gp1QCx4"/>
-<div class="absolute bottom-0 right-0 w-2.5 h-2.5 bg-green-500 border-2 border-[#121212] rounded-full shadow-lg"></div>
+<div class="absolute bottom-0 right-0 w-2.5 h-2.5 bg-green-500 border-2 border-background rounded-full shadow-lg"></div>
 </div>
-<div class="flex flex-col -gap-1">
+<div class="flex flex-col gap-0">
 <h1 class="text-white font-bold text-sm tracking-tight">Jan de Vries</h1>
 <span class="text-[10px] text-green-500 font-medium tracking-wide uppercase">Online</span>
 </div>
@@ -124,7 +124,7 @@
 <span class="text-white font-semibold text-sm">Canyon Speedmax</span>
 <span class="bg-zinc-800 text-zinc-400 text-[10px] px-2 py-0.5 rounded-full uppercase font-bold tracking-widest">Te koop</span>
 </div>
-<span class="text-[#9fcafc] font-bold text-lg leading-tight">€ 149,00</span>
+<span class="text-secondary-fixed-dim font-bold text-lg leading-tight">€ 149,00</span>
 </div>
 </div>
 <!-- Thread Date Separator -->
@@ -143,7 +143,7 @@
 </div>
 <!-- Buyer Message (Right) -->
 <div class="flex flex-col gap-1 items-end max-w-[85%] self-end">
-<div class="bg-[#d1430a] text-white p-4 rounded-2xl rounded-tr-none text-sm leading-relaxed shadow-[0_4px_12px_rgba(169,50,0,0.3)]">
+<div class="bg-primary-container text-white p-4 rounded-2xl rounded-tr-none text-sm leading-relaxed shadow-[0_4px_12px_rgba(169,50,0,0.3)]">
                     Ja, nog beschikbaar! Wanneer kun je langskomen?
                 </div>
 <div class="flex items-center gap-1 mr-1">
@@ -178,7 +178,7 @@
 </div>
 </main>
 <!-- Fixed Bottom Interaction Area -->
-<footer class="fixed bottom-0 w-full bg-[#121212] z-[60] pb-10 px-4 pt-3">
+<footer class="fixed bottom-0 w-full bg-background z-[60] pb-10 px-4 pt-3">
 <!-- Input Bar -->
 <div class="flex items-center gap-3 bg-zinc-900/80 backdrop-blur-md p-2 pl-4 rounded-[28px] border border-zinc-800/50">
 <button class="text-zinc-400 hover:text-white transition-colors" aria-label="Camera">
@@ -191,7 +191,7 @@
                         Bod
                     </button>
 </div>
-<button class="w-10 h-10 rounded-full bg-[#d1430a] flex items-center justify-center text-white shadow-[0_4px_12px_rgba(169,50,0,0.4)] active:scale-90 transition-transform" aria-label="Send">
+<button class="w-10 h-10 rounded-full bg-primary-container flex items-center justify-center text-white shadow-[0_4px_12px_rgba(169,50,0,0.4)] active:scale-90 transition-transform" aria-label="Send">
 <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1;">send</span>
 </button>
 </div>

--- a/docs/screens/06-chat/designs/chat_thread_mobile_dark/screen.png
+++ b/docs/screens/06-chat/designs/chat_thread_mobile_dark/screen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1aefd9ac577397f43c37603b5a04f7afcad41356c554e86377c43d474d9a3d4a
+size 156070

--- a/docs/screens/SCREEN-MAP.md
+++ b/docs/screens/SCREEN-MAP.md
@@ -27,8 +27,8 @@
 | `lib/features/shipping/presentation/screens/tracking_screen.dart` | [02-tracking-timeline.md](05-shipping/02-tracking-timeline.md) | `05-shipping/designs/tracking_*` (4) |
 | `lib/features/shipping/presentation/screens/parcel_shop_selector_screen.dart` | [03-parcel-shop-selector.md](05-shipping/03-parcel-shop-selector.md) | `05-shipping/designs/parcel_*` (4) |
 | `lib/features/messages/presentation/screens/conversation_list_screen.dart` | [01-conversation-list.md](06-chat/01-conversation-list.md) | `06-chat/designs/messages_*` (4) |
-| `lib/features/messages/presentation/screens/chat_thread_screen.dart` | [02-chat-thread.md](06-chat/02-chat-thread.md) | `06-chat/designs/chat_*` (6) |
-| *(Scam alert — embedded widget)* | [03-scam-alert.md](06-chat/03-scam-alert.md) | `06-chat/designs/scam_*` (2) |
+| `lib/features/messages/presentation/screens/chat_thread_screen.dart` | [02-chat-thread.md](06-chat/02-chat-thread.md) | `06-chat/designs/chat_*` (4) |
+| *(Scam alert — embedded widget)* | [03-scam-alert.md](06-chat/03-scam-alert.md) | `06-chat/designs/scam_*` (4) |
 | `lib/features/profile/presentation/screens/own_profile_screen.dart` | [01-own-profile.md](07-profile/01-own-profile.md) | `07-profile/designs/own_*` (4) |
 | `lib/features/profile/presentation/screens/public_profile_screen.dart` | [02-seller-profile.md](07-profile/02-seller-profile.md) | `07-profile/designs/public_*` (5) |
 | `lib/features/profile/presentation/screens/settings_screen.dart` | [03-settings.md](07-profile/03-settings.md) | `07-profile/designs/settings_*` (4) |


### PR DESCRIPTION
## Summary

- Adds the missing `chat_thread_mobile_dark` design reference (PNG + HTML) that issue #164 flagged as the last blocker for the P-43 screenshot pipeline coverage.
- Derived from the existing `chat_thread_mobile_dark_scam_alert` sibling (same dark tokens, same persona, same phone frame) with the scam banner removed — keeps the two variants visually aligned so reviewers can diff them side-by-side.
- Renders at **670×1600** to match sibling convention (verified against `chat_thread_mobile_dark_scam_alert` and `messages_mobile_dark`).
- Material Symbols Outlined icons render correctly (force-loaded via explicit axis URL — the `wght@100..700,0..1` unicode-range URL is ORB-blocked in headless Chrome).

## Housekeeping

- `docs/SPRINT-PLAN.md` — marks **P-43 complete** (PR #161 merged the ASO work; this PR retires the remaining designer-handoff blocker).
- `docs/screens/SCREEN-MAP.md` — corrects pre-existing variant-count drift: `chat_*` 6 → 4, `scam_*` 2 → 4 (matches actual directory listing).
- `docs/PLAN-p43-dark-mode-chat-golden.md` — implementation plan (senior-staff decision trail per `.agent/workflows/plan.md`).

## Scope

Docs/design-assets only. **Zero `lib/` changes**, **zero test changes**. The `chat_thread` screenshot pipeline (`test/screenshots/drivers/chat_thread_screenshot_test.dart`) already loops over `ScreenshotTheme.values` — this PR provides the reference PNG that golden-diff reviewers compare against on macOS.

## Test plan

- [x] Local: `bash scripts/check_screenshots.sh` — 240 PNGs, all within size budget.
- [x] Local: `dart run scripts/check_quality.dart` — no Dart changes, nothing to check.
- [x] PNG dimension parity: `670×1600` matches sibling `chat_thread_mobile_dark_scam_alert`.
- [x] Visual sanity: Material Symbols glyphs render (no `arrow_back` text), phone frame fills canvas, dark tokens match `DeelmarktColors.darkScaffold` (#121212) + `DeelmarktColors.darkOnSurface` (#f2f2f2).
- [ ] CI: golden diff job (macOS) remains green after merge — `chat_thread_mobile_dark` goldens already exist; this PR adds the *reference design* used for manual spec comparison, not the golden itself.

Closes #164.