### PR TITLE
fix(security): suspension gate fails closed on sanction lookup error

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -152,7 +152,12 @@ GoRouter createRouter({
         currentPath: state.matchedLocation,
       );
       if (asyncRedirect != null) return asyncRedirect;
-      final hasActiveSanction = sanctionAsync.valueOrNull?.isActive ?? false;
+      // Treat an error as an active sanction so that authRedirect's
+      // _sanctionRedirect does NOT release the user from /suspended while the
+      // provider is still in error state (i.e. the redirect-cycle bypass).
+      final hasActiveSanction =
+          sanctionAsync.hasError ||
+          (sanctionAsync.valueOrNull?.isActive ?? false);
 
       return authRedirect(
         isLoading: false, // Supabase is always initialized before runApp
@@ -209,7 +214,9 @@ String? sanctionAsyncRedirect({
   required String currentPath,
 }) {
   if (!isLoggedIn) return null;
-  if (sanctionAsync.isLoading && currentPath != AppRoutes.splash) {
+  if (sanctionAsync.isLoading &&
+      currentPath != AppRoutes.splash &&
+      !currentPath.startsWith(AppRoutes.suspended)) {
     return AppRoutes.splash;
   }
   if (sanctionAsync.hasError && !currentPath.startsWith(AppRoutes.suspended)) {

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -146,13 +146,12 @@ GoRouter createRouter({
       // via refreshListenable; use invalidate + notifyListeners to trigger
       // re-evaluation when sanction state changes.
       final sanctionAsync = ref.read(activeSanctionProvider);
-      // While sanction is loading and the user is logged in, hold on splash
-      // to prevent a flash of home before the gate can activate.
-      if (isLoggedIn &&
-          sanctionAsync.isLoading &&
-          state.matchedLocation != AppRoutes.splash) {
-        return AppRoutes.splash;
-      }
+      final asyncRedirect = sanctionAsyncRedirect(
+        isLoggedIn: isLoggedIn,
+        sanctionAsync: sanctionAsync,
+        currentPath: state.matchedLocation,
+      );
+      if (asyncRedirect != null) return asyncRedirect;
       final hasActiveSanction = sanctionAsync.valueOrNull?.isActive ?? false;
 
       return authRedirect(
@@ -184,6 +183,44 @@ bool _isSessionExpired(Session session) {
   return DateTime.now().toUtc().isAfter(
     expiry.subtract(const Duration(seconds: 30)),
   );
+}
+
+/// Maps the current [activeSanctionProvider] [AsyncValue] to a router
+/// redirect, enforcing the P-53 suspension gate's loading + error semantics.
+///
+/// - **Loading + logged in**: hold on `/splash` to prevent a flash of `/home`
+///   before the gate can activate.
+/// - **Error + logged in**: fail-CLOSED — route to `/suspended`. A
+///   suspended/banned user must NOT be able to bypass the gate by forcing
+///   the sanction lookup to fail (e.g. dropping the network). The
+///   [SuspensionGateScreen] surfaces the error with a retry CTA; a
+///   successful retry that resolves to `null` releases the user back to
+///   `/home`.
+/// - **Data**: returns `null` — the data branch is handled by [authRedirect]
+///   via the `hasActiveSanction` flag.
+///
+/// Reference: Gemini security review on PR #171, comment id 3096148637 —
+/// the previous implementation defaulted to `false` on error (fail-OPEN),
+/// allowing suspended users through during transport failures.
+@visibleForTesting
+String? sanctionAsyncRedirect({
+  required bool isLoggedIn,
+  required AsyncValue<SanctionEntity?> sanctionAsync,
+  required String currentPath,
+}) {
+  if (!isLoggedIn) return null;
+  if (sanctionAsync.isLoading && currentPath != AppRoutes.splash) {
+    return AppRoutes.splash;
+  }
+  if (sanctionAsync.hasError && !currentPath.startsWith(AppRoutes.suspended)) {
+    AppLogger.warning(
+      'Sanction lookup failed — fail-closed redirect to /suspended',
+      tag: 'router',
+      error: sanctionAsync.error,
+    );
+    return AppRoutes.suspended;
+  }
+  return null;
 }
 
 /// Test-only factory — accepts a pre-configured redirect function.

--- a/test/core/router/suspension_fail_closed_test.dart
+++ b/test/core/router/suspension_fail_closed_test.dart
@@ -14,6 +14,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:deelmarkt/core/router/app_router.dart';
+import 'package:deelmarkt/core/router/auth_guard.dart';
 import 'package:deelmarkt/core/router/routes.dart';
 import 'package:deelmarkt/features/profile/domain/entities/sanction_entity.dart';
 
@@ -119,6 +120,32 @@ void main() {
       );
     });
 
+    // M1 fix: loading during retry from /suspended must NOT flash to /splash
+    test(
+      'logged-in + loading + on /suspended → no redirect (retry in-page)',
+      () {
+        expect(
+          sanctionAsyncRedirect(
+            isLoggedIn: true,
+            sanctionAsync: loading,
+            currentPath: AppRoutes.suspended,
+          ),
+          isNull,
+        );
+      },
+    );
+
+    test('logged-in + loading + on /suspended/appeal → no redirect', () {
+      expect(
+        sanctionAsyncRedirect(
+          isLoggedIn: true,
+          sanctionAsync: loading,
+          currentPath: AppRoutes.suspendedAppeal,
+        ),
+        isNull,
+      );
+    });
+
     test('logged-out + loading → no redirect', () {
       expect(
         sanctionAsyncRedirect(
@@ -164,5 +191,82 @@ void main() {
         );
       },
     );
+  });
+
+  // Full-pipeline tests (M2 fix): verify that the router does NOT release
+  // a user from /suspended when the provider is in error state — the bug
+  // existed because sanctionAsyncRedirect returned null (loop prevention)
+  // and then hasActiveSanction defaulted to false, causing authRedirect to
+  // send the user back to /home. Fixed by H1: hasActiveSanction = hasError || ...
+  group('full pipeline — /suspended user stays gated on error', () {
+    final error = AsyncValue<SanctionEntity?>.error(
+      Exception('network down'),
+      StackTrace.empty,
+    );
+
+    // Simulates what app_router.dart does: sanctionAsyncRedirect first,
+    // then authRedirect with hasActiveSanction derived from the same AsyncValue.
+    String? fullPipelineRedirect({
+      required AsyncValue<SanctionEntity?> sanctionAsync,
+      required String currentPath,
+    }) {
+      final asyncRedirect = sanctionAsyncRedirect(
+        isLoggedIn: true,
+        sanctionAsync: sanctionAsync,
+        currentPath: currentPath,
+      );
+      if (asyncRedirect != null) return asyncRedirect;
+      final hasActiveSanction =
+          sanctionAsync.hasError ||
+          (sanctionAsync.valueOrNull?.isActive ?? false);
+      return authRedirect(
+        isLoading: false,
+        isLoggedIn: true,
+        currentPath: currentPath,
+        hasActiveSanction: hasActiveSanction,
+      );
+    }
+
+    test(
+      'user on /suspended with error → stays on /suspended (no release)',
+      () {
+        expect(
+          fullPipelineRedirect(
+            sanctionAsync: error,
+            currentPath: AppRoutes.suspended,
+          ),
+          isNull,
+          reason: 'Must remain on /suspended while provider is in error state',
+        );
+      },
+    );
+
+    test('user on /suspended/appeal with error → stays (no release)', () {
+      expect(
+        fullPipelineRedirect(
+          sanctionAsync: error,
+          currentPath: AppRoutes.suspendedAppeal,
+        ),
+        isNull,
+      );
+    });
+
+    test('user on /suspended with AsyncData(null) → released to /home', () {
+      expect(
+        fullPipelineRedirect(
+          sanctionAsync: const AsyncValue<SanctionEntity?>.data(null),
+          currentPath: AppRoutes.suspended,
+        ),
+        AppRoutes.home,
+        reason: 'No error and no active sanction — user should be released',
+      );
+    });
+
+    test('user on /home with error → redirected to /suspended', () {
+      expect(
+        fullPipelineRedirect(sanctionAsync: error, currentPath: AppRoutes.home),
+        AppRoutes.suspended,
+      );
+    });
   });
 }

--- a/test/core/router/suspension_fail_closed_test.dart
+++ b/test/core/router/suspension_fail_closed_test.dart
@@ -1,0 +1,168 @@
+/// Tests for [sanctionAsyncRedirect] — fail-CLOSED suspension gate behaviour.
+///
+/// Background: Gemini flagged a HIGH security issue on PR #171 (comment id
+/// 3096148637) — the suspension gate previously read
+/// `sanctionAsync.valueOrNull?.isActive ?? false`, which defaulted to `false`
+/// when the provider was in an error state. A suspended/banned user could
+/// bypass the gate by forcing the sanction lookup to fail (e.g. by dropping
+/// the network during the request).
+///
+/// Reference: lib/core/router/app_router.dart
+library;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:deelmarkt/core/router/app_router.dart';
+import 'package:deelmarkt/core/router/routes.dart';
+import 'package:deelmarkt/features/profile/domain/entities/sanction_entity.dart';
+
+void main() {
+  group('sanctionAsyncRedirect — fail-CLOSED on AsyncError', () {
+    final error = AsyncValue<SanctionEntity?>.error(
+      Exception('network down'),
+      StackTrace.empty,
+    );
+
+    test(
+      'logged-in user on /home → /suspended when sanction lookup errored',
+      () {
+        expect(
+          sanctionAsyncRedirect(
+            isLoggedIn: true,
+            sanctionAsync: error,
+            currentPath: AppRoutes.home,
+          ),
+          AppRoutes.suspended,
+        );
+      },
+    );
+
+    test('logged-in user on /sell → /suspended on error (no bypass)', () {
+      expect(
+        sanctionAsyncRedirect(
+          isLoggedIn: true,
+          sanctionAsync: error,
+          currentPath: AppRoutes.sell,
+        ),
+        AppRoutes.suspended,
+      );
+    });
+
+    test('logged-in user on /messages → /suspended on error (no bypass)', () {
+      expect(
+        sanctionAsyncRedirect(
+          isLoggedIn: true,
+          sanctionAsync: error,
+          currentPath: AppRoutes.messages,
+        ),
+        AppRoutes.suspended,
+      );
+    });
+
+    test('already on /suspended → no redirect (no loop)', () {
+      expect(
+        sanctionAsyncRedirect(
+          isLoggedIn: true,
+          sanctionAsync: error,
+          currentPath: AppRoutes.suspended,
+        ),
+        isNull,
+      );
+    });
+
+    test('already on /suspended/appeal → no redirect (no loop)', () {
+      expect(
+        sanctionAsyncRedirect(
+          isLoggedIn: true,
+          sanctionAsync: error,
+          currentPath: AppRoutes.suspendedAppeal,
+        ),
+        isNull,
+      );
+    });
+
+    test('not logged in → no redirect (gate only applies to authed users)', () {
+      expect(
+        sanctionAsyncRedirect(
+          isLoggedIn: false,
+          sanctionAsync: error,
+          currentPath: AppRoutes.home,
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('sanctionAsyncRedirect — loading state', () {
+    const loading = AsyncValue<SanctionEntity?>.loading();
+
+    test('logged-in + loading + not on /splash → /splash', () {
+      expect(
+        sanctionAsyncRedirect(
+          isLoggedIn: true,
+          sanctionAsync: loading,
+          currentPath: AppRoutes.home,
+        ),
+        AppRoutes.splash,
+      );
+    });
+
+    test('logged-in + loading + already on /splash → no redirect', () {
+      expect(
+        sanctionAsyncRedirect(
+          isLoggedIn: true,
+          sanctionAsync: loading,
+          currentPath: AppRoutes.splash,
+        ),
+        isNull,
+      );
+    });
+
+    test('logged-out + loading → no redirect', () {
+      expect(
+        sanctionAsyncRedirect(
+          isLoggedIn: false,
+          sanctionAsync: loading,
+          currentPath: AppRoutes.home,
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('sanctionAsyncRedirect — data state delegates to authRedirect', () {
+    test('AsyncData(null) → no redirect (no sanction)', () {
+      expect(
+        sanctionAsyncRedirect(
+          isLoggedIn: true,
+          sanctionAsync: const AsyncValue<SanctionEntity?>.data(null),
+          currentPath: AppRoutes.home,
+        ),
+        isNull,
+      );
+    });
+
+    test(
+      'AsyncData(sanction) → no redirect here (handled by authRedirect)',
+      () {
+        final sanction = SanctionEntity(
+          id: 's1',
+          userId: 'u1',
+          type: SanctionType.suspension,
+          reason: 'test',
+          createdAt: DateTime.now().subtract(const Duration(days: 1)),
+          expiresAt: DateTime.now().add(const Duration(days: 6)),
+        );
+        expect(
+          sanctionAsyncRedirect(
+            isLoggedIn: true,
+            sanctionAsync: AsyncValue<SanctionEntity?>.data(sanction),
+            currentPath: AppRoutes.home,
+          ),
+          isNull,
+        );
+      },
+    );
+  });
+}

--- a/test/integration/suspension_flow_integration_test.dart
+++ b/test/integration/suspension_flow_integration_test.dart
@@ -165,62 +165,30 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
-  // Scenario E — fail-open: sanction error does NOT block the user
+  // Scenario E — fail-CLOSED: sanction error routes user to /suspended
   // ---------------------------------------------------------------------------
-  // POLICY DECISION (documented here intentionally):
+  // POLICY (revised after Gemini PR #171 HIGH security finding,
+  // comment id 3096148637):
   //   When activeSanctionProvider throws (e.g. network outage, Supabase down),
-  //   `sanctionAsync.valueOrNull` returns null, so `hasActiveSanction` defaults
-  //   to false. This is a deliberate fail-OPEN design: availability takes
-  //   priority over strict enforcement during backend outages. The trade-off is
-  //   that a suspended user on a poor connection may temporarily bypass the gate.
-  //   Mitigation: RLS policies on the backend still enforce access at the DB level.
+  //   the redirect closure in app_router.dart treats the error as a gate
+  //   activation and routes logged-in users to /suspended. This is a deliberate
+  //   fail-CLOSED design: a suspended/banned user must NOT be able to bypass
+  //   the gate by forcing the sanction lookup to fail.
+  //
+  //   The /suspended screen surfaces the error with a retry CTA; if the retry
+  //   resolves to `null` (no active sanction), the router immediately releases
+  //   the user back to /home — so a non-suspended user with a transient
+  //   network blip sees a brief retry screen rather than silently bypassing
+  //   the gate.
+  //
+  //   Defence in depth: RLS policies on the backend still enforce access at
+  //   the DB level; the client-side gate is the first line of defence.
   // ---------------------------------------------------------------------------
-
-  group('Scenario E — sanction provider error → fail-open', () {
-    test(
-      'authRedirect passes user through when hasActiveSanction=false (error case)',
-      () {
-        // Simulate: sanctionAsync.valueOrNull == null (from AsyncError or AsyncData(null))
-        // hasActiveSanction computed as: null?.isActive ?? false = false
-        final redirect = authRedirect(
-          isLoading: false,
-          isLoggedIn: true,
-          currentPath: '/',
-          hasActiveSanction:
-              false, // ignore: avoid_redundant_argument_values — error state → null → false (fail-open)
-        );
-        // EXPECTED: fail-open — user stays on /home, not redirected to /suspended.
-        expect(
-          redirect,
-          isNull,
-          reason: 'Fail-open: sanction error must not trap the user',
-        );
-      },
-    );
-
-    test(
-      'authRedirect does NOT redirect to /suspended when hasActiveSanction=false',
-      () {
-        // failOpenValue: AsyncError → valueOrNull=null → isActive ?? false = false
-        // ignore: avoid_redundant_argument_values
-        const failOpenValue = false;
-        for (final path in ['/', '/sell', '/messages', '/profile']) {
-          final redirect = authRedirect(
-            isLoading: false,
-            isLoggedIn: true,
-            currentPath: path,
-            hasActiveSanction:
-                failOpenValue, // ignore: avoid_redundant_argument_values
-          );
-          expect(
-            redirect,
-            isNot(equals('/suspended')),
-            reason: 'Path $path must not redirect to /suspended on error',
-          );
-        }
-      },
-    );
-  });
+  // The fail-closed branch lives in app_router.dart's redirect closure (it
+  // inspects `sanctionAsync.hasError` directly, before calling authRedirect).
+  // Pure-logic tests of authRedirect can't exercise that branch — it's
+  // covered by the widget test in
+  // test/core/router/suspension_fail_closed_test.dart.
 
   group('GoRouterRefreshStream — sanity', () {
     test('notifies listeners on stream event', () async {


### PR DESCRIPTION
## Summary

- Closes a HIGH-severity security bypass in the P-53 suspension gate. Previously, when `activeSanctionProvider` was in an `AsyncError` state (e.g. network outage, Supabase unavailable), the redirect closure read `sanctionAsync.valueOrNull?.isActive ?? false`, defaulting to `false` and letting suspended/banned users through.
- Introduces `sanctionAsyncRedirect()` which fails **closed**: logged-in users hit a transport error → routed to `/suspended`, where `SuspensionGateScreen` renders the error with a retry CTA. A successful retry that resolves to `null` releases the user back to `/home`.
- Updates the integration test's documented "Scenario E" policy from fail-OPEN to fail-CLOSED, and adds 11 unit tests covering loading / error / data branches across `/home`, `/sell`, `/messages`, `/suspended`, `/suspended/appeal`.

## Background

Flagged by [gemini-code-assist](https://github.com/apps/gemini-code-assist) on [apps#171](https://github.com/deelmarkt-org/app/pull/171) (review comment id 3096148637) as a HIGH security finding. The vulnerable code was introduced in [apps#153](https://github.com/deelmarkt-org/app/pull/153) (suspension gate epic) and is pre-existing on `dev` — it is **not** in PR #171's diff, so it is being addressed in this focused branch.

### Defence in depth

Backend RLS policies on `account_sanctions` already restrict mutations server-side. This client-side gate is the first line of defence; the change closes the bypass at the navigation layer.

## Test plan

- [x] `flutter test test/core/router/suspension_fail_closed_test.dart` — 11/11 pass
- [x] `flutter test test/core/router/` — 71/71 pass (no regressions in `auth_guard_test`, `auth_guard_suspension_test`, `admin_guard_test`, `splash_screen_test`)
- [x] `flutter test test/integration/suspension_flow_integration_test.dart` — pass (Scenario E rewritten to document fail-closed policy)
- [x] `flutter analyze` — clean
- [ ] CI: full test suite + SonarCloud + Gemini review pass on this PR