### PR TITLE
chore(ci): Codemagic beta distribution + OWASP ZAP weekly scan [B-05, B-34]

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -273,6 +273,10 @@ jobs:
     timeout-minutes: 45
     # Only run when STAGING_URL is configured.
     if: ${{ vars.STAGING_URL != '' }}
+    # Job-level env so the Slack step's `if:` guard can evaluate SLACK_WEBHOOK_URL.
+    # Step-level env is not available during `if:` expression evaluation.
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -336,7 +340,6 @@ jobs:
       - name: Notify Slack
         if: always() && env.SLACK_WEBHOOK_URL != ''
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           HIGH: ${{ steps.parse.outputs.high_count }}
           MED:  ${{ steps.parse.outputs.med_count }}
           RUN:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -263,3 +263,102 @@ jobs:
           else
             echo "All Actions pinned."
           fi
+
+  # ──────────────────────────────────────────────
+  # 5. OWASP ZAP — web app scanner (staging)
+  # ──────────────────────────────────────────────
+  zap-scan:
+    name: OWASP ZAP Web Scan (Staging)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # Only run when STAGING_URL is configured.
+    if: ${{ vars.STAGING_URL != '' }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: ZAP full scan
+        uses: zaproxy/action-full-scan@70c8d444bc63672c4f7a16dc1a0190eee5458e5b # v0.10.0
+        with:
+          target: ${{ vars.STAGING_URL }}
+          rules_file_name: '.zap/rules.tsv'
+          cmd_options: '-a'
+          # fail_action false — WARN/FAIL rules in rules.tsv drive Slack alert instead.
+          fail_action: false
+
+      - name: Parse ZAP report and build summary
+        if: always()
+        run: |
+          REPORT="report_json.json"
+          if [ ! -f "$REPORT" ]; then
+            echo "ZAP report not found — scan may have failed to start."
+            exit 0
+          fi
+
+          python3 << 'PYEOF'
+          import json, os, sys
+
+          with open('report_json.json') as f:
+              data = json.load(f)
+
+          alerts = data.get('site', [{}])[0].get('alerts', [])
+          by_risk = {'High': [], 'Medium': [], 'Low': [], 'Informational': []}
+          for a in alerts:
+              risk = a.get('riskdesc', 'Informational').split(' ')[0]
+              by_risk.setdefault(risk, []).append(a.get('alert', 'Unknown'))
+
+          lines = ['## OWASP ZAP Scan Results']
+          for level in ('High', 'Medium', 'Low', 'Informational'):
+              items = by_risk.get(level, [])
+              emoji = {'High': '🔴', 'Medium': '🟠', 'Low': '🟡', 'Informational': '🔵'}[level]
+              lines.append(f'{emoji} **{level}**: {len(items)}')
+              for name in items[:5]:
+                  lines.append(f'  - {name}')
+              if len(items) > 5:
+                  lines.append(f'  - …and {len(items) - 5} more')
+
+          summary = '\n'.join(lines)
+          print(summary)
+
+          # Write to $GITHUB_STEP_SUMMARY
+          summary_path = os.environ.get('GITHUB_STEP_SUMMARY', '/dev/null')
+          with open(summary_path, 'a') as f:
+              f.write(summary + '\n')
+
+          # Set outputs for Slack step
+          high_count = len(by_risk.get('High', []))
+          med_count  = len(by_risk.get('Medium', []))
+          with open(os.environ.get('GITHUB_OUTPUT', '/dev/null'), 'a') as f:
+              f.write(f'high_count={high_count}\n')
+              f.write(f'med_count={med_count}\n')
+          PYEOF
+
+      - name: Notify Slack
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          HIGH: ${{ steps.parse.outputs.high_count }}
+          MED:  ${{ steps.parse.outputs.med_count }}
+          RUN:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          COLOR="good"
+          [ "${HIGH:-0}" -gt 0 ] && COLOR="danger"
+          [ "${HIGH:-0}" -eq 0 ] && [ "${MED:-0}" -gt 0 ] && COLOR="warning"
+
+          curl -s -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "{
+              \"attachments\": [{
+                \"color\": \"$COLOR\",
+                \"title\": \"OWASP ZAP — DeelMarkt Staging\",
+                \"text\": \"High: ${HIGH:-?}  Medium: ${MED:-?}\",
+                \"footer\": \"<$RUN|View run>\"
+              }]
+            }"
+
+      - name: Upload ZAP HTML report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: zap-report
+          path: report_html.html
+          retention-days: 30

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -286,6 +286,7 @@ jobs:
           fail_action: false
 
       - name: Parse ZAP report and build summary
+        id: parse
         if: always()
         run: |
           REPORT="report_json.json"

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,0 +1,28 @@
+# OWASP ZAP passive/active scan rules — DeelMarkt staging
+# Format: RuleId<TAB>Action<TAB>Reason
+# Actions: IGNORE (suppress), WARN (report but no fail), FAIL (hard fail)
+#
+# Flutter web and Cloudflare edge introduce patterns that trigger ZAP
+# false positives. Suppress known-safe findings here; review annually.
+
+# Content Security Policy — Flutter web bootstrap requires 'unsafe-inline'
+# for its inline script tag. This is a framework constraint, not a project flaw.
+10038	IGNORE	Flutter web requires CSP unsafe-inline in bootstrap; not exploitable
+
+# X-Frame-Options — set at the Cloudflare edge (not in app-level headers).
+# ZAP scans the origin, not the CDN layer, so it doesn't see the edge header.
+10020	IGNORE	X-Frame-Options set at Cloudflare edge; not visible to ZAP origin scan
+
+# Storable and Cacheable Content — CDN caching is intentional for static assets.
+10049	IGNORE	CDN cache headers on static Flutter web assets are by design
+
+# Server header leaks — Supabase and Cloudflare add server headers that
+# cannot be stripped without paid-tier WAF rules.
+10036	WARN	Server header exposed by upstream (Supabase/Cloudflare); low risk
+
+# Missing Anti-CSRF — Flutter web SPA uses Authorization headers (not cookies)
+# for all state-mutating requests; CSRF via form POST is not applicable.
+10202	IGNORE	SPA uses Authorization header Bearer tokens; CSRF via form not applicable
+
+# Timestamp disclosure — Supabase response timestamps are intentional metadata.
+10096	IGNORE	Supabase timestamps in JSON responses are intentional API data

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -11,7 +11,8 @@
 
 # X-Frame-Options — set at the Cloudflare edge (not in app-level headers).
 # ZAP scans the origin, not the CDN layer, so it doesn't see the edge header.
-10020	IGNORE	X-Frame-Options set at Cloudflare edge; not visible to ZAP origin scan
+# WARN (not IGNORE) so we detect if edge config drifts and stops emitting the header.
+10020	WARN	X-Frame-Options set at Cloudflare edge; WARN to catch edge config drift
 
 # Storable and Cacheable Content — CDN caching is intentional for static assets.
 10049	IGNORE	CDN cache headers on static Flutter web assets are by design
@@ -21,8 +22,9 @@
 10036	WARN	Server header exposed by upstream (Supabase/Cloudflare); low risk
 
 # Missing Anti-CSRF — Flutter web SPA uses Authorization headers (not cookies)
-# for all state-mutating requests; CSRF via form POST is not applicable.
-10202	IGNORE	SPA uses Authorization header Bearer tokens; CSRF via form not applicable
+# for all state-mutating requests; CSRF via form POST is not applicable for SPA endpoints.
+# WARN (not IGNORE) to surface any cookie-authenticated admin/Supabase endpoints if they appear.
+10202	WARN	SPA uses Bearer tokens; WARN to catch any future cookie-auth endpoints
 
 # Timestamp disclosure — Supabase response timestamps are intentional metadata.
 10096	IGNORE	Supabase timestamps in JSON responses are intentional API data

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -18,7 +18,9 @@
 #   ASC_DEMO_PASSWORD                 — Reviewer demo account password (1Password)
 
 definitions:
-  flutter_version: &flutter_version "3.x"
+  # Aligned with GitHub Actions setup-flutter (channel: stable, no explicit version).
+  # Pin to an exact version (e.g. "3.29.3") once the team standardises on a release.
+  flutter_version: &flutter_version stable
 
   # Shared Flutter setup steps reused in both workflows.
   flutter_setup: &flutter_setup

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -53,7 +53,9 @@ workflows:
 
     environment:
       flutter: *flutter_version
-      xcode: latest
+      # Pin to an explicit Xcode release for reproducible iOS builds.
+      # Update this when the team upgrades Xcode (check codemagic.io/pricing for available versions).
+      xcode: "16.2"
       cocoapods: default
       vars:
         BUNDLE_ID: nl.deelmarkt.deelmarkt
@@ -127,10 +129,10 @@ workflows:
     artifacts: *android_artifacts
 
     publishing:
-      google_play:
-        credentials: $GOOGLE_PLAY_JSON_KEY
-        track: internal
-        submit_as_draft: true
+      # google_play publishing block intentionally omitted.
+      # Fastlane android_beta (supply) is the single publish path — avoids
+      # double-upload race where CM and Fastlane would both try to submit
+      # the same AAB and one would fail with "version already exists".
       email:
         recipients:
           - info.deelmarkt@gmail.com

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -74,7 +74,8 @@ workflows:
 
       - name: Install pods
         script: |
-          find . -name "Podfile" -execdir pod install \;
+          # Explicit target — `find -execdir` can stray into .pub-cache Podfiles.
+          cd ios && pod install
 
       - name: Build & upload via Fastlane
         script: |

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1,0 +1,137 @@
+# DeelMarkt — Codemagic CI/CD
+#
+# Workflows:
+#   ios-testflight      — Flutter iOS build → TestFlight (triggers on push to main)
+#   android-play-internal — Flutter Android AAB → Play internal track (triggers on push to main)
+#
+# Required secrets (set in Codemagic dashboard → Team → Global variables):
+#   APP_STORE_CONNECT_KEY_IDENTIFIER  — Key ID from App Store Connect API key
+#   APP_STORE_CONNECT_ISSUER_ID       — Issuer ID from App Store Connect
+#   APP_STORE_CONNECT_PRIVATE_KEY     — .p8 contents of the API key (PEM)
+#   CERTIFICATE_PRIVATE_KEY           — Private key matching the signing certificate
+#   CM_MATCH_REPO                     — HTTPS URL of the Match certificates repo
+#   MATCH_PASSWORD                    — Encryption passphrase for Match repo
+#   GOOGLE_PLAY_JSON_KEY              — Google Play service account JSON (base64 or raw)
+#   APPLE_ID                          — Apple ID email (used by Fastfile Appfile)
+#   ITC_TEAM_ID                       — App Store Connect team ID
+#   ASC_DEMO_USER                     — Reviewer demo account email (1Password)
+#   ASC_DEMO_PASSWORD                 — Reviewer demo account password (1Password)
+
+definitions:
+  flutter_version: &flutter_version "3.x"
+
+  # Shared Flutter setup steps reused in both workflows.
+  flutter_setup: &flutter_setup
+    - name: Set up Flutter
+      script: |
+        flutter pub get
+        dart run build_runner build --delete-conflicting-outputs
+
+  # Shared artifact export paths.
+  ios_artifacts: &ios_artifacts
+    - build/ios/DeelMarkt.ipa
+    - /tmp/xcodebuild_logs/*.log
+
+  android_artifacts: &android_artifacts
+    - build/app/outputs/bundle/release/app-release.aab
+
+workflows:
+  # ─── iOS → TestFlight ────────────────────────────────────────────────────────
+  ios-testflight:
+    name: iOS → TestFlight
+    max_build_duration: 90
+    instance_type: mac_mini_m2
+
+    triggering:
+      events:
+        - push
+      branch_patterns:
+        - pattern: main
+          include: true
+
+    environment:
+      flutter: *flutter_version
+      xcode: latest
+      cocoapods: default
+      vars:
+        BUNDLE_ID: nl.deelmarkt.deelmarkt
+        XCODE_SCHEME: Runner
+        XCODE_WORKSPACE: Runner.xcworkspace
+      app_store_connect:
+        key_id: $APP_STORE_CONNECT_KEY_IDENTIFIER
+        issuer_id: $APP_STORE_CONNECT_ISSUER_ID
+        key: $APP_STORE_CONNECT_PRIVATE_KEY
+      ios_signing:
+        distribution_type: app_store
+        bundle_identifier: nl.deelmarkt.deelmarkt
+
+    scripts:
+      - *flutter_setup
+
+      - name: Install pods
+        script: |
+          find . -name "Podfile" -execdir pod install \;
+
+      - name: Build & upload via Fastlane
+        script: |
+          # CM_COMMIT_MESSAGE is used as TestFlight changelog.
+          export CM_COMMIT_MESSAGE="${CM_COMMIT_MESSAGE:-$(git log -1 --pretty=%s)}"
+          cd fastlane
+          bundle exec fastlane ios ios_beta
+
+    artifacts: *ios_artifacts
+
+    publishing:
+      email:
+        recipients:
+          - info.deelmarkt@gmail.com
+        notify:
+          success: true
+          failure: true
+
+  # ─── Android → Play internal ─────────────────────────────────────────────────
+  android-play-internal:
+    name: Android → Play internal
+    max_build_duration: 60
+    instance_type: linux_x2
+
+    triggering:
+      events:
+        - push
+      branch_patterns:
+        - pattern: main
+          include: true
+
+    environment:
+      flutter: *flutter_version
+      vars:
+        PACKAGE_NAME: nl.deelmarkt.deelmarkt
+
+    scripts:
+      - *flutter_setup
+
+      - name: Set up keystore
+        script: |
+          # Keystore is injected via Codemagic code signing (Android keystore).
+          # No manual keytool step needed — CM exports the file and sets
+          # FCI_KEYSTORE_PATH, FCI_KEY_ALIAS, FCI_KEY_PASSWORD, FCI_KEYSTORE_PASSWORD.
+          echo "Keystore path: $FCI_KEYSTORE_PATH"
+
+      - name: Build & upload via Fastlane
+        script: |
+          cd fastlane
+          bundle exec fastlane android android_beta
+
+    artifacts: *android_artifacts
+
+    publishing:
+      google_play:
+        credentials: $GOOGLE_PLAY_JSON_KEY
+        track: internal
+        submit_as_draft: true
+      email:
+        recipients:
+          - info.deelmarkt@gmail.com
+        notify:
+          success: true
+          failure: true

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -52,6 +52,29 @@ platform :ios do
     UI.success "iOS metadata uploaded successfully"
   end
 
+  # Build + sign + upload to TestFlight (Codemagic CI calls this).
+  lane :ios_beta do
+    _preflight
+    match(
+      type: "appstore",
+      readonly: true,
+    )
+    build_app(
+      workspace: "Runner.xcworkspace",
+      scheme: "Runner",
+      configuration: "Release",
+      export_method: "app-store",
+      output_directory: "build/ios",
+      output_name: "DeelMarkt.ipa",
+    )
+    upload_to_testflight(
+      api_key_path: ENV["ASC_API_KEY_JSON"],
+      skip_waiting_for_build_processing: true,
+      changelog: ENV.fetch("CM_COMMIT_MESSAGE", "Beta build"),
+    )
+    UI.success "iOS beta uploaded to TestFlight"
+  end
+
   # Dry-run: validates metadata + screenshots locally without uploading.
   lane :deliver_dry_run do
     _preflight
@@ -84,6 +107,30 @@ platform :android do
       screenshots_path: "fastlane/android/screenshots",
     )
     UI.success "Android screenshots uploaded successfully"
+  end
+
+  # Build AAB + upload to Play internal track (Codemagic CI calls this).
+  lane :android_beta do
+    gradle(
+      task: "bundle",
+      build_type: "Release",
+      project_dir: "android/",
+      properties: {
+        "flutter.buildMode" => "release",
+      },
+    )
+    supply(
+      json_key: ENV["GOOGLE_PLAY_JSON_KEY"],
+      package_name: "nl.deelmarkt.deelmarkt",
+      aab: "build/app/outputs/bundle/release/app-release.aab",
+      track: "internal",
+      skip_upload_apk: true,
+      skip_upload_metadata: true,
+      skip_upload_changelogs: true,
+      skip_upload_screenshots: true,
+      release_status: "draft",
+    )
+    UI.success "Android beta uploaded to Play internal track"
   end
 
   # Upload metadata only to Play Console.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -122,7 +122,9 @@ platform :android do
     )
     supply(
       json_key: ENV["GOOGLE_PLAY_JSON_KEY"],
-      package_name: "nl.deelmarkt.deelmarkt",
+      # PACKAGE_NAME is exported by codemagic.yaml env; default keeps the lane
+      # runnable locally via `bundle exec fastlane android android_beta`.
+      package_name: ENV["PACKAGE_NAME"] || "nl.deelmarkt.deelmarkt",
       aab: "build/app/outputs/bundle/release/app-release.aab",
       track: "internal",
       skip_upload_apk: true,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -111,6 +111,7 @@ platform :android do
 
   # Build AAB + upload to Play internal track (Codemagic CI calls this).
   lane :android_beta do
+    _android_preflight
     gradle(
       task: "bundle",
       build_type: "Release",
@@ -172,6 +173,19 @@ private_lane :_preflight do
       "Missing required ENV: #{missing.join(", ")}. " \
       "See the team vault entries 'App Store reviewer' (demo account) " \
       "and 'App Store Connect API key' for each value."
+    )
+  end
+end
+
+# Fail fast if any ENV required by `supply` (android_beta) is missing.
+# Mirrors _preflight convention established for iOS lanes.
+private_lane :_android_preflight do
+  required = ["GOOGLE_PLAY_JSON_KEY"] # pragma: allowlist secret
+  missing = required.select { |k| ENV[k].to_s.empty? }
+  unless missing.empty?
+    UI.user_error!(
+      "Missing required ENV: #{missing.join(", ")}. " \
+      "See the team vault entry 'Google Play service account' for the key."
     )
   end
 end

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -1,0 +1,22 @@
+# DeelMarkt Matchfile
+#
+# Manages iOS code signing via fastlane Match (git storage).
+# Repository URL is set via CM_MATCH_REPO env var (Codemagic secret).
+#
+# Required environment variables (Codemagic secrets / GitHub Secrets):
+#   CM_MATCH_REPO          — HTTPS URL to the private certificates repo
+#   MATCH_PASSWORD         — Encryption passphrase for the certificates repo
+#   ASC_API_KEY_JSON       — App Store Connect API key JSON
+
+git_url(ENV["CM_MATCH_REPO"])
+
+storage_mode("git")
+
+type("appstore")
+
+app_identifier(["nl.deelmarkt.deelmarkt"])
+
+username(ENV["APPLE_ID"])
+
+# Readonly in CI — certificates are provisioned by the team, not regenerated.
+readonly(true)


### PR DESCRIPTION
## Summary

- **B-05 (Codemagic):** Adds `codemagic.yaml` with two CI workflows (`ios-testflight`, `android-play-internal`). Both trigger on pushes to `main`. iOS uses fastlane Match (readonly git signing) + `ios_beta` lane → TestFlight. Android uses `android_beta` lane → Play internal track (draft).
- **B-34 (OWASP ZAP):** Adds `.zap/rules.tsv` with Flutter/Cloudflare false-positive suppressions and a new `zap-scan` job (#5) in `security-audit.yml`. Runs weekly alongside existing security jobs; sends Slack alert with High/Medium counts; uploads HTML report as 30-day artifact.

## Files changed

| File | Change |
|------|--------|
| `codemagic.yaml` | NEW — ios-testflight + android-play-internal workflows |
| `fastlane/Matchfile` | NEW — git-based iOS code signing (readonly in CI) |
| `fastlane/Fastfile` | UPDATED — `ios_beta` and `android_beta` lanes added |
| `.zap/rules.tsv` | NEW — ZAP rule suppressions (Flutter/Cloudflare false positives) |
| `.github/workflows/security-audit.yml` | UPDATED — ZAP job #5 added |

## Environment variables required (set manually — not in this PR)

**GitHub Secrets / Vars (B-34):**
- `vars.STAGING_URL` — ZAP scan target; job is skipped when unset
- `secrets.SLACK_WEBHOOK_URL` — Slack incoming webhook for alerts

**Codemagic Dashboard (B-05):**
- `APP_STORE_CONNECT_KEY_IDENTIFIER`, `APP_STORE_CONNECT_ISSUER_ID`, `APP_STORE_CONNECT_PRIVATE_KEY`
- `CERTIFICATE_PRIVATE_KEY`, `CM_MATCH_REPO`, `MATCH_PASSWORD`
- `GOOGLE_PLAY_JSON_KEY`
- `APPLE_ID`, `ITC_TEAM_ID`, `ASC_DEMO_USER`, `ASC_DEMO_PASSWORD`

## Test plan

- [ ] Verify `codemagic.yaml` passes schema validation in Codemagic dashboard
- [ ] Trigger `ios-testflight` workflow manually on a test build; confirm IPA appears in TestFlight
- [ ] Trigger `android-play-internal` workflow manually; confirm AAB lands in Play internal track as draft
- [ ] Set `STAGING_URL` secret and trigger `security-audit.yml` via `workflow_dispatch`; confirm ZAP job runs and Slack message is posted
- [ ] Verify ZAP HTML report artifact is uploaded and downloadable
- [ ] Confirm existing 4 security jobs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)