### PR TITLE
feat(escrow): GH-59 backend-authoritative eligibility (PR-B)

### DIFF
--- a/docs/adr/ADR-023-escrow-eligibility-authority.md
+++ b/docs/adr/ADR-023-escrow-eligibility-authority.md
@@ -31,13 +31,13 @@ A client-derived badge will diverge from server-side eligibility the moment E03 
    ```sql
    ALTER TABLE listings ADD COLUMN escrow_eligible BOOLEAN NOT NULL DEFAULT false;
    ```
-2. **Computation** (reso): `BEFORE INSERT OR UPDATE` trigger sets `escrow_eligible` from:
-   - `status = 'active'`
+2. **Computation** (reso): `BEFORE INSERT OR UPDATE` trigger sets `escrow_eligible` from (matching the shipped `compute_escrow_eligible_for` function in `20260420154314_listings_escrow_eligible.sql`):
+   - `is_active = true AND is_sold = false` (listings uses two booleans rather than a `status` ENUM — see [phase-a migration](../../supabase/migrations/20260329161637_phase_a_user_profiles_listings_categories_b39_to_b44.sql#L125-L126))
    - `price_cents >= 5000`
    - `quality_score >= 50`
-   - Seller's `user_profiles.kyc_level >= 1`
-   - Seller not suspended, no active dispute count > 2 in last 90 days
-   - Category is escrow-eligible (excludes services, digital goods — see `categories.escrow_eligible` flag)
+   - Seller's `user_profiles.kyc_level <> 'level0'` (ENUM; `level0` is unverified)
+   - Category is escrow-eligible (`categories.escrow_eligible` — excludes services, digital goods)
+   - **Deferred**: dispute-count predicate (seller not suspended, no active dispute count > 2 in last 90 days) — waits on the `disputes` table shipping with E03 Phase 2. Tracked by the TODO in the migration function.
 3. **DTO** (belengaz): `ListingDto` gains `escrowEligible: bool` (default `false` on deserialization failure — **fail-closed**).
 4. **Entity** (pizmam): `ListingEntity.isEscrowAvailable` is a **final field**, not a getter. Default `false`. Tests cover the fail-closed default.
 5. **UI** (pizmam): `EscrowBadge` shown only when `listing.isEscrowAvailable && unleash.isEnabled('listings_escrow_badge')`.
@@ -47,7 +47,7 @@ A client-derived badge will diverge from server-side eligibility the moment E03 
 
 #### Positive
 - Single source of truth; client and server cannot diverge.
-- Audit trail: `escrow_eligible` flips are logged via `audit_log` table (existing infra).
+- Audit trail: `escrow_eligible` flips are captured by the standard `updated_at` touch on `listings` (triggered by the primary + cascade functions). Long-form audit records land in the existing `audit_logs` table (plural — `20260403100000_r20_account_deletion_support.sql`).
 - Server-side update can expand rules without app release.
 - Fail-closed default (`false`) means any serialization error hides the badge rather than showing a wrong one.
 - Legal defensibility: "badge displayed == row stated eligible at fetch time" is a defensible UI claim.

--- a/lib/features/home/data/dto/listing_dto.dart
+++ b/lib/features/home/data/dto/listing_dto.dart
@@ -1,3 +1,4 @@
+import 'package:deelmarkt/core/services/app_logger.dart';
 import 'package:deelmarkt/features/home/domain/entities/listing_entity.dart';
 
 /// DTO for converting Supabase REST JSON to [ListingEntity].
@@ -6,6 +7,12 @@ import 'package:deelmarkt/features/home/domain/entities/listing_entity.dart';
 /// with descriptive message instead of opaque TypeError.
 class ListingDto {
   const ListingDto._();
+
+  /// Fires the "escrow_eligible missing" warning **at most once per
+  /// process**. List screens pull 20+ listings per render, so without a
+  /// guard the warning would flood Crashlytics on a stale-view deploy.
+  /// The first hit is the one that needs attention; after that it is noise.
+  static bool _missingEscrowWarned = false;
 
   /// Parse a Supabase JSON row from `listings_with_favourites` view.
   static ListingEntity fromJson(Map<String, dynamic> json) {
@@ -52,8 +59,32 @@ class ListingDto {
       status: ListingStatus.fromDb((json['status'] as String?) ?? 'active'),
       viewCount: (json['view_count'] as int?) ?? 0,
       favouriteCount: (json['favourite_count'] as int?) ?? 0,
+      isEscrowAvailable: _parseEscrowEligible(json),
       createdAt: DateTime.tryParse(createdAtRaw) ?? DateTime.now(),
     );
+  }
+
+  /// Fail-closed parse of the `escrow_eligible` column.
+  ///
+  /// Returns `false` whenever the key is missing, null, or not a boolean.
+  /// Logs a warning **once per process** when the key is absent because
+  /// that signals the `listings_with_favourites` view or RPC projection
+  /// is stale — something humans should investigate, even though the
+  /// user-facing behaviour (badge hidden) is safe. ADR-023.
+  static bool _parseEscrowEligible(Map<String, dynamic> json) {
+    if (!json.containsKey('escrow_eligible')) {
+      if (!_missingEscrowWarned) {
+        _missingEscrowWarned = true;
+        AppLogger.warning(
+          'escrow_eligible missing from listing JSON — defaulting false. '
+          'Check listings_with_favourites view column list.',
+          tag: 'ListingDto',
+        );
+      }
+      return false;
+    }
+    final raw = json['escrow_eligible'];
+    return raw is bool ? raw : false;
   }
 
   /// Convert [ListingEntity] to Supabase INSERT/UPDATE JSON.

--- a/lib/features/home/domain/entities/listing_entity.dart
+++ b/lib/features/home/domain/entities/listing_entity.dart
@@ -35,6 +35,7 @@ class ListingEntity extends Equatable {
     this.status = ListingStatus.active,
     this.viewCount = 0,
     this.favouriteCount = 0,
+    this.isEscrowAvailable = false,
   });
 
   /// Sentinel for [copyWith] — distinguishes "not passed" from "passed as null".
@@ -72,6 +73,16 @@ class ListingEntity extends Equatable {
   /// Number of times this listing has been favourited. Defaults to 0.
   final int favouriteCount;
 
+  /// Whether this listing is currently escrow-eligible.
+  ///
+  /// **Server-authoritative** — computed by a Postgres trigger from the
+  /// listing's status, price, quality score, the seller's KYC level, and
+  /// the category's own `escrow_eligible` flag. The client **never**
+  /// derives this value; it reads the DB column via [ListingDto].
+  /// Defaults to `false` (fail-closed) so serialisation failures or
+  /// pre-trigger rows never flash a wrong badge. See ADR-023.
+  final bool isEscrowAvailable;
+
   final DateTime createdAt;
 
   /// Creates a copy with the given fields replaced.
@@ -97,6 +108,7 @@ class ListingEntity extends Equatable {
     ListingStatus? status,
     int? viewCount,
     int? favouriteCount,
+    bool? isEscrowAvailable,
     DateTime? createdAt,
   }) {
     return ListingEntity(
@@ -118,6 +130,7 @@ class ListingEntity extends Equatable {
       status: status ?? this.status,
       viewCount: viewCount ?? this.viewCount,
       favouriteCount: favouriteCount ?? this.favouriteCount,
+      isEscrowAvailable: isEscrowAvailable ?? this.isEscrowAvailable,
       createdAt: createdAt ?? this.createdAt,
     );
   }
@@ -147,6 +160,7 @@ class ListingEntity extends Equatable {
     status,
     viewCount,
     favouriteCount,
+    isEscrowAvailable,
     createdAt,
   ];
 }

--- a/supabase/migrations/20260420154314_listings_escrow_eligible.sql
+++ b/supabase/migrations/20260420154314_listings_escrow_eligible.sql
@@ -1,0 +1,195 @@
+-- ──────────────────────────────────────────────────────────────────────────
+-- GH-59 / ADR-023 — Backend-authoritative escrow eligibility
+--
+-- Adds a `escrow_eligible` boolean on `listings`, computed server-side by
+-- trigger from the listing's status + price + quality score + the seller's
+-- KYC level + the category's own eligibility flag. The Dart DTO reads this
+-- column with a fail-closed default (false), so a misrendered badge is
+-- impossible as long as the trigger is intact.
+--
+-- Dispute-count predicate (ADR-023 §Decision rule 2e) is deferred because
+-- the `disputes` table ships in E03 Phase 2 — see TODO below.
+--
+-- Cascades:
+--   * INSERT / UPDATE on listings       → recompute THAT row (BEFORE trigger)
+--   * UPDATE of kyc_level on profile    → recompute ALL seller's listings
+--   * UPDATE of categories.escrow_eligible → recompute ALL listings in
+--                                           that category
+--
+-- Rollback: pair with `<ts>_listings_escrow_eligible_down.sql` which
+-- drops the triggers, function, and column (additive migration — safe).
+-- ──────────────────────────────────────────────────────────────────────────
+
+-- 1. Prerequisite column on categories (D-1) — ADR-023 §Decision rule 2f.
+--    Defaults to TRUE so no category is excluded until product defines the
+--    excluded list; individual categories can later be switched off via
+--    UPDATE and the cascade trigger will flip dependent listings in one
+--    statement.
+ALTER TABLE categories
+  ADD COLUMN IF NOT EXISTS escrow_eligible BOOLEAN NOT NULL DEFAULT true;
+
+COMMENT ON COLUMN categories.escrow_eligible IS
+  'Whether listings in this category may be escrow-eligible. Default true '
+  'for MVP; tighten per-category via follow-up migration once product '
+  'defines excluded categories (services, digital goods). ADR-023.';
+
+-- 2. The new column on listings. Fail-safe default = false so rows added
+--    before the trigger fires never render a badge.
+ALTER TABLE listings
+  ADD COLUMN IF NOT EXISTS escrow_eligible BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN listings.escrow_eligible IS
+  'Server-computed escrow eligibility. Set by trg_listings_escrow_eligible '
+  'on every INSERT/UPDATE. Client-read-only — NEVER derive client-side. '
+  'ADR-023.';
+
+-- 3. Shared computation function. Takes a listing's inputs + the seller id
+--    + the category id and returns the eligibility boolean. Pure read —
+--    marked STABLE so the trigger and the one-shot backfill can both call
+--    it without the planner re-evaluating per row.
+--
+-- TODO(E03): Re-add the dispute-count predicate once the `disputes` table
+-- ships. Target rule from ADR-023: COUNT(disputes WHERE seller_id = X AND
+-- status = 'active' AND created_at > now() - 90 days) <= 2.
+CREATE OR REPLACE FUNCTION compute_escrow_eligible_for(
+  p_seller_id      UUID,
+  p_is_active      BOOLEAN,
+  p_is_sold        BOOLEAN,
+  p_price_cents    INT,
+  p_quality_score  INT,
+  p_category_id    UUID
+) RETURNS BOOLEAN
+LANGUAGE plpgsql VOLATILE AS $$
+DECLARE
+  v_kyc_level         TEXT;
+  v_category_eligible BOOLEAN;
+BEGIN
+  -- Reads user_profiles + categories; both tables have public-read RLS
+  -- (20260329161637 policies user_profiles_select + categories_select use
+  -- USING (true)), so no SECURITY DEFINER is needed today. If those
+  -- policies are ever tightened, mark this function SECURITY DEFINER
+  -- owned by a role that retains SELECT on both tables — otherwise the
+  -- COALESCE chain will silently flip every badge off.
+  SELECT kyc_level::TEXT INTO v_kyc_level
+    FROM user_profiles WHERE id = p_seller_id;
+
+  SELECT escrow_eligible INTO v_category_eligible
+    FROM categories WHERE id = p_category_id;
+
+  RETURN (
+    COALESCE(p_is_active, false)                 AND
+    COALESCE(p_is_sold, false)             = false AND
+    COALESCE(p_price_cents, 0)            >= 5000 AND
+    COALESCE(p_quality_score, 0)          >= 50   AND
+    COALESCE(v_kyc_level, 'level0')       <> 'level0' AND
+    COALESCE(v_category_eligible, false)
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION compute_escrow_eligible_for IS
+  'Pure read helper — shared by trg_listings_escrow_eligible, the cascade '
+  'triggers, and the backfill UPDATE. Declared VOLATILE so per-row trigger '
+  'evaluations inside multi-row UPDATE statements (cascades) always re-read '
+  'user_profiles.kyc_level and categories.escrow_eligible instead of caching '
+  'the first invocation''s result.';
+
+-- 4. Primary trigger: recompute on every listing INSERT/UPDATE.
+CREATE OR REPLACE FUNCTION trg_listings_recompute_escrow()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.escrow_eligible := compute_escrow_eligible_for(
+    NEW.seller_id,
+    NEW.is_active,
+    NEW.is_sold,
+    NEW.price_cents,
+    NEW.quality_score,
+    NEW.category_id
+  );
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_listings_escrow_eligible ON listings;
+CREATE TRIGGER trg_listings_escrow_eligible
+  BEFORE INSERT OR UPDATE ON listings
+  FOR EACH ROW EXECUTE FUNCTION trg_listings_recompute_escrow();
+
+-- 5. Cascade on user_profiles.kyc_level change (D-4). When a seller gains
+--    or loses a KYC level, every one of their listings is recomputed in a
+--    single UPDATE — the primary trigger above fires for each row so the
+--    computation stays consistent.
+CREATE OR REPLACE FUNCTION trg_user_profiles_cascade_escrow()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  IF OLD.kyc_level IS DISTINCT FROM NEW.kyc_level THEN
+    -- Only rewrite listings whose computed eligibility actually changes.
+    -- The IS DISTINCT FROM predicate avoids write amplification and spurious
+    -- Realtime fan-out on rows whose result did not move.
+    UPDATE listings SET updated_at = now()
+    WHERE seller_id = NEW.id
+      AND escrow_eligible IS DISTINCT FROM compute_escrow_eligible_for(
+        seller_id, is_active, is_sold, price_cents, quality_score, category_id
+      );
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_user_profiles_kyc_cascade ON user_profiles;
+CREATE TRIGGER trg_user_profiles_kyc_cascade
+  AFTER UPDATE OF kyc_level ON user_profiles
+  FOR EACH ROW EXECUTE FUNCTION trg_user_profiles_cascade_escrow();
+
+-- 6. Cascade on categories.escrow_eligible change. Same pattern as kyc —
+--    a single UPDATE touches every listing in the category so the primary
+--    trigger recomputes per row.
+CREATE OR REPLACE FUNCTION trg_categories_cascade_escrow()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  IF OLD.escrow_eligible IS DISTINCT FROM NEW.escrow_eligible THEN
+    UPDATE listings SET updated_at = now()
+    WHERE category_id = NEW.id
+      AND escrow_eligible IS DISTINCT FROM compute_escrow_eligible_for(
+        seller_id, is_active, is_sold, price_cents, quality_score, category_id
+      );
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_categories_escrow_cascade ON categories;
+CREATE TRIGGER trg_categories_escrow_cascade
+  AFTER UPDATE OF escrow_eligible ON categories
+  FOR EACH ROW EXECUTE FUNCTION trg_categories_cascade_escrow();
+
+-- 7. One-shot backfill via the helper (D-6). Single pass, no write
+--    amplification on rows that already match the computed value.
+UPDATE listings SET
+  escrow_eligible = compute_escrow_eligible_for(
+    seller_id,
+    is_active,
+    is_sold,
+    price_cents,
+    quality_score,
+    category_id
+  )
+WHERE escrow_eligible IS DISTINCT FROM compute_escrow_eligible_for(
+  seller_id,
+  is_active,
+  is_sold,
+  price_cents,
+  quality_score,
+  category_id
+);
+
+-- 8. Partial index so future "filter by escrow" search queries are fast
+--    without paying storage cost on the 90%+ rows that are ineligible.
+CREATE INDEX IF NOT EXISTS idx_listings_escrow_eligible
+  ON listings (escrow_eligible)
+  WHERE escrow_eligible = true;
+
+-- 9. RLS — escrow_eligible is a public trust signal (ADR-023 §Decision +
+--    F-8 audit finding). No row-level change needed: the existing SELECT
+--    policy already exposes listing columns to anon + authenticated when
+--    the row passes the active/unsold/not-deleted gate.

--- a/supabase/migrations/20260420154314_listings_escrow_eligible.sql
+++ b/supabase/migrations/20260420154314_listings_escrow_eligible.sql
@@ -44,13 +44,21 @@ COMMENT ON COLUMN listings.escrow_eligible IS
   'ADR-023.';
 
 -- 3. Shared computation function. Takes a listing's inputs + the seller id
---    + the category id and returns the eligibility boolean. Pure read —
---    marked STABLE so the trigger and the one-shot backfill can both call
---    it without the planner re-evaluating per row.
+--    + the category id and returns the eligibility boolean.
 --
--- TODO(E03): Re-add the dispute-count predicate once the `disputes` table
--- ships. Target rule from ADR-023: COUNT(disputes WHERE seller_id = X AND
--- status = 'active' AND created_at > now() - 90 days) <= 2.
+--    Declared VOLATILE (not STABLE) so that per-row invocations inside the
+--    cascade UPDATEs below always re-read the current kyc_level and
+--    category.escrow_eligible. A STABLE function would let the planner cache
+--    the first row's read and reuse it for every subsequent row — fine for a
+--    single-row INSERT trigger, but unsafe in the AFTER UPDATE cascades where
+--    the underlying row that changed (user_profiles / categories) is being
+--    applied to many listings in one statement. See COMMENT ON FUNCTION below.
+--
+-- TODO(GH-59/E03 Phase 2): Re-add the dispute-count predicate once the
+-- `disputes` table ships. Target rule from ADR-023 §Decision rule 2e:
+-- COUNT(disputes WHERE seller_id = X AND status = 'active'
+--       AND created_at > now() - 90 days) <= 2.
+-- Tracking: https://github.com/deelmarkt-org/app/issues/59
 CREATE OR REPLACE FUNCTION compute_escrow_eligible_for(
   p_seller_id      UUID,
   p_is_active      BOOLEAN,

--- a/supabase/migrations/20260420154315_listings_escrow_eligible_down.sql
+++ b/supabase/migrations/20260420154315_listings_escrow_eligible_down.sql
@@ -1,0 +1,42 @@
+-- ──────────────────────────────────────────────────────────────────────────
+-- Paired rollback for 20260420154314_listings_escrow_eligible.sql
+--
+-- Additive migration — rollback drops all objects in reverse dependency
+-- order. No data loss: `listings.escrow_eligible` and
+-- `categories.escrow_eligible` are server-computed trust signals; any app
+-- surface reading them falls back to `false` via the DTO fail-closed path
+-- once the columns disappear (ADR-023 §Rollback).
+--
+-- Apply only when rolling GH-59 / ADR-023 back end-to-end; the Unleash flag
+-- `listings_escrow_badge` should be flipped OFF first (seconds-level kill)
+-- to hide all badges before this runs.
+--
+-- NOT auto-applied — commit path is manual via `supabase db push` against
+-- the target environment. Present in git as of GH-59 PR-B so on-call does
+-- not have to craft it by hand at 3 AM.
+-- ──────────────────────────────────────────────────────────────────────────
+
+-- 1. Drop cascade triggers first so the primary trigger stops being invoked
+--    transitively during DROP.
+DROP TRIGGER IF EXISTS trg_categories_escrow_cascade ON categories;
+DROP FUNCTION IF EXISTS trg_categories_cascade_escrow();
+
+DROP TRIGGER IF EXISTS trg_user_profiles_kyc_cascade ON user_profiles;
+DROP FUNCTION IF EXISTS trg_user_profiles_cascade_escrow();
+
+-- 2. Drop the primary trigger + its function.
+DROP TRIGGER IF EXISTS trg_listings_escrow_eligible ON listings;
+DROP FUNCTION IF EXISTS trg_listings_recompute_escrow();
+
+-- 3. Drop the shared helper function.
+DROP FUNCTION IF EXISTS compute_escrow_eligible_for(
+  UUID, BOOLEAN, BOOLEAN, INT, INT, UUID
+);
+
+-- 4. Drop the partial index.
+DROP INDEX IF EXISTS idx_listings_escrow_eligible;
+
+-- 5. Drop the columns. listings before categories because nothing on
+--    categories references listings.
+ALTER TABLE listings DROP COLUMN IF EXISTS escrow_eligible;
+ALTER TABLE categories DROP COLUMN IF EXISTS escrow_eligible;

--- a/test/features/home/data/dto/listing_dto_test.dart
+++ b/test/features/home/data/dto/listing_dto_test.dart
@@ -131,5 +131,64 @@ void main() {
       final entity = ListingDto.fromJson(json);
       expect(entity.condition, ListingCondition.good);
     });
+
+    group('escrow_eligible parse (ADR-023, fail-closed)', () {
+      test('maps escrow_eligible=true to isEscrowAvailable=true', () {
+        final entity = ListingDto.fromJson({
+          ...sampleJson,
+          'escrow_eligible': true,
+        });
+        expect(entity.isEscrowAvailable, isTrue);
+      });
+
+      test('maps escrow_eligible=false to isEscrowAvailable=false', () {
+        final entity = ListingDto.fromJson({
+          ...sampleJson,
+          'escrow_eligible': false,
+        });
+        expect(entity.isEscrowAvailable, isFalse);
+      });
+
+      test('missing escrow_eligible key → false (fail-closed)', () {
+        final entity = ListingDto.fromJson(sampleJson);
+        expect(entity.isEscrowAvailable, isFalse);
+      });
+
+      test('escrow_eligible=null → false (fail-closed)', () {
+        final entity = ListingDto.fromJson({
+          ...sampleJson,
+          'escrow_eligible': null,
+        });
+        expect(entity.isEscrowAvailable, isFalse);
+      });
+
+      test('escrow_eligible=non-bool (e.g. "true" string) → false', () {
+        final entity = ListingDto.fromJson({
+          ...sampleJson,
+          'escrow_eligible': 'true',
+        });
+        expect(entity.isEscrowAvailable, isFalse);
+      });
+
+      test('escrow_eligible=1 (integer truthy) → false (strict bool-only)', () {
+        // Supabase REST can serialise booleans as integers in rare RPC
+        // projections; the DTO must not coerce 1 to true — that would
+        // bypass the server-authoritative boolean contract.
+        final entity = ListingDto.fromJson({
+          ...sampleJson,
+          'escrow_eligible': 1,
+        });
+        expect(entity.isEscrowAvailable, isFalse);
+      });
+
+      test('toJson does NOT include escrow_eligible (server-owned)', () {
+        final entity = ListingDto.fromJson({
+          ...sampleJson,
+          'escrow_eligible': true,
+        });
+        final json = ListingDto.toJson(entity);
+        expect(json.containsKey('escrow_eligible'), isFalse);
+      });
+    });
   });
 }

--- a/test/features/home/domain/entities/listing_entity_test.dart
+++ b/test/features/home/domain/entities/listing_entity_test.dart
@@ -166,4 +166,46 @@ void main() {
       expect(ListingCondition.values, contains(ListingCondition.poor));
     });
   });
+
+  group('ListingEntity.isEscrowAvailable', () {
+    test('defaults to false (fail-closed, ADR-023)', () {
+      expect(listing.isEscrowAvailable, isFalse);
+    });
+
+    test('can be set via the constructor', () {
+      final eligible = ListingEntity(
+        id: 'test-2',
+        title: 'Eligible',
+        description: 'desc',
+        priceInCents: 10000,
+        sellerId: 'user-1',
+        sellerName: 'Test',
+        condition: ListingCondition.good,
+        categoryId: 'cat-1',
+        imageUrls: const [],
+        createdAt: DateTime(2026),
+        isEscrowAvailable: true,
+      );
+      expect(eligible.isEscrowAvailable, isTrue);
+    });
+
+    test('copyWith toggles the value while preserving others', () {
+      final flipped = listing.copyWith(isEscrowAvailable: true);
+      expect(flipped.isEscrowAvailable, isTrue);
+      expect(flipped.id, equals(listing.id));
+      expect(flipped.priceInCents, equals(listing.priceInCents));
+    });
+
+    test('copyWith without isEscrowAvailable keeps the current value', () {
+      final eligible = listing.copyWith(isEscrowAvailable: true);
+      final reTitled = eligible.copyWith(title: 'New title');
+      expect(reTitled.isEscrowAvailable, isTrue);
+    });
+
+    test('equality distinguishes entities that differ only by escrow flag', () {
+      final eligible = listing.copyWith(isEscrowAvailable: true);
+      expect(eligible, isNot(equals(listing)));
+      expect(eligible.hashCode, isNot(equals(listing.hashCode)));
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Backend half of GitHub issue [#59](https://github.com/deelmarkt-org/app/issues/59), implementing [ADR-023](../blob/fix/gh59-escrow-badge-backend/docs/adr/ADR-023-escrow-eligibility-authority.md).

The client becomes a strict reader of an authoritative server boolean — no client-side derivation, no possibility of buyer-screen / checkout divergence. This closes the EU Consumer Rights Directive legal risk documented in ADR-023.

## What ships

### Migration `supabase/migrations/20260420154314_listings_escrow_eligible.sql`

| Piece | Purpose |
|-------|---------|
| `categories.escrow_eligible BOOLEAN NOT NULL DEFAULT true` | Prerequisite column (plan D-1). Default `true` unblocks the trigger without requiring product to enumerate excluded categories upfront. |
| `listings.escrow_eligible BOOLEAN NOT NULL DEFAULT false` | The authoritative flag the client reads. Default `false` — fail-safe. |
| `compute_escrow_eligible_for(...)` | Shared plpgsql helper. **VOLATILE** (not STABLE) so cascade UPDATEs always re-read `user_profiles.kyc_level` and `categories.escrow_eligible`. COALESCE chain fail-closes on NULL inputs. |
| `trg_listings_escrow_eligible` (BEFORE INSERT/UPDATE) | Primary authority. Owner UPDATE cannot override the boolean. |
| `trg_user_profiles_kyc_cascade` (AFTER UPDATE OF kyc_level) | Cascades a seller's KYC change to all their listings. Guarded by `IS DISTINCT FROM` so unchanged rows aren't rewritten. |
| `trg_categories_escrow_cascade` (AFTER UPDATE OF escrow_eligible) | Same pattern, scoped by `category_id`. |
| One-shot backfill | `IS DISTINCT FROM` predicate so no-op rows aren't touched. |
| Partial index `idx_listings_escrow_eligible WHERE escrow_eligible = true` | Small, fast, ready for future "filter by escrow" search. |

### DTO + Entity

- `ListingDto._parseEscrowEligible()` — strict-bool fail-closed parser. Missing key, null, strings, and integers all yield `false`. Missing-key warning is **rate-limited to once per process** so a stale-view deploy doesn't flood Crashlytics at 20 events per list page.
- `ListingDto.toJson()` deliberately excludes `escrow_eligible` — server-owned.
- `ListingEntity.isEscrowAvailable: bool = false` — added to constructor, `copyWith`, `props`.

### Tests (12 new)

- 5 entity tests (default, constructor, copyWith paths, props equality)
- 7 DTO tests (true / false / missing / null / string / integer / toJson-exclusion)

## Deferred

- Dispute-count predicate from ADR-023 §Decision rule 2e — waits on the `disputes` table (E03 Phase 2). Tracked by TODO in the migration.
- UI wire-up — PR-C (frontend) follows, blocked by this PR landing in staging.

## Tier-1 Audit

Three parallel audits pre-push:

| Audit | Verdict | Fixes Applied |
|-------|---------|---------------|
| Database review | REVISE → RESOLVED | 🔴 `STABLE`→`VOLATILE` (cascade correctness), 🟡 `IS DISTINCT FROM` guard on both cascade triggers, 🟢 RLS dependency documented inline |
| Flutter review | SHIP-WITH-NOTES → IMPROVED | 🟡 Logger rate-limited, 🟢 integer-coercion test added |
| Security scan | CLEAN-WITH-NOTES | All injection/privesc/secret scans clean. GDPR: new column leaks strictly less than existing `seller_kyc_level` in `listings_with_favourites`. |

## Test plan

- [x] `flutter analyze` — zero warnings on changed files
- [x] `flutter test test/features/home/` — 38 new + existing tests pass
- [x] `dart run scripts/check_quality.dart` — 2 files clean
- [x] `bash scripts/check_edge_functions.sh` — *script only validates `.ts` Edge Functions; reported "No staged TypeScript files to check" for this PR. Migration schema was manually cross-referenced against the phase-a migration (`is_active`/`is_sold` booleans, no `status` ENUM).*
- [x] Pre-push hooks — all green (strict analyze + coverage + deployment drift)
- [ ] **STAGING** (reso): apply migration, insert eligible listing, flip seller KYC `level2`→`level0`, verify cascade in <1s
- [ ] **STAGING** (reso): psql assert `listings_with_favourites` view exposes `escrow_eligible` via `l.*`
- [ ] **STAGING** (reso): verify backfill leaves existing rows at the correct computed value

## Dependencies

- **Blocks PR-C** (GH-59 UI): Frontend wire-up cannot merge until this migration is applied to the target environment.
- Unleash flag `listings_escrow_badge` stays **OFF** in prod until staging QA passes.

Plan: the original `docs/PLAN-gh113-gh59-polish-escrow.md` was removed in PR-A (commit `a92790a`) per reviewer precedent (PR #173 M-10 / PR #181 L-1). The authoritative plan is the Senior Staff audit revision, whose decisions (D-1 through D-7) are inlined in the *What ships* / *Deferred* / *Tier-1 Audit* sections above and in [ADR-023](../blob/fix/gh59-escrow-badge-backend/docs/adr/ADR-023-escrow-eligibility-authority.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
