### PR TITLE
feat(escrow): GH-59 EscrowBadge UI (PR-C, DRAFT — blocked by #183)

### DIFF
--- a/docs/FEATURE-FLAGS.md
+++ b/docs/FEATURE-FLAGS.md
@@ -8,13 +8,14 @@
 
 | Flag key | Feature | Added | Owner | Prod status | Kill criteria |
 |:---------|:--------|:------|:------|:------------|:--------------|
-| `listings_escrow_badge` | EscrowBadge on listing cards (issue #59, ADR-023) | 2026-04-17 | pizmam + product | OFF (awaiting reso migration) | checkout 409 rate > 2% OR badge accuracy complaint |
+| `listings_escrow_badge` | EscrowBadge on listing cards (issue #59, ADR-023) | 2026-04-17 | pizmam + product | OFF in prod — staged rollout after PR-B migration + PR-C UI land in staging (dev 100% → staging 100% → prod 10% canary → prod 100%) | checkout 409 rate > 2% OR badge accuracy complaint |
 
 ## Rollout Log
 
 | Flag | Date | Action | Approver |
 |:-----|:-----|:-------|:---------|
 | `listings_escrow_badge` | 2026-04-17 | Registered, default OFF | pizmam |
+| `listings_escrow_badge` | 2026-04-20 | Wired into `EscrowAwareListingCard` via `FeatureFlags.listingsEscrowBadge` constant (GH-59 PR-C); stays OFF in prod until staging QA passes per plan §4.4 | pizmam |
 
 ## Governance
 

--- a/docs/adr/ADR-023-escrow-eligibility-authority.md
+++ b/docs/adr/ADR-023-escrow-eligibility-authority.md
@@ -2,7 +2,7 @@
 
 ### Status
 
-**Accepted — Implementation pending** — Decision ratified 2026-04-17 · Author: pizmam · **Blocks:** GitHub issue [#59](https://github.com/deelmarkt-org/app/issues/59) · **Waiting on:** reso (`supabase/migrations/*_listings_escrow_eligible.sql` + trigger) · belengaz (`ListingDto.escrowEligible` field)
+**Accepted — Implementation in review** — Decision ratified 2026-04-17 · Author: pizmam · Updated 2026-04-20 · **Blocks:** GitHub issue [#59](https://github.com/deelmarkt-org/app/issues/59) · **PR-B (backend):** [#183](https://github.com/deelmarkt-org/app/pull/183) — migration + DTO + entity · **PR-C (UI):** draft — `EscrowAwareListingCard` behind Unleash `listings_escrow_badge` · **Dispute-count predicate** (§Decision rule 2e) deferred to E03 Phase 2 (`disputes` table not yet shipped). Audit trail still flows via `audit_logs` (plural, not `audit_log`) per 20260403 migration.
 
 ### Context
 

--- a/lib/core/services/unleash_service.dart
+++ b/lib/core/services/unleash_service.dart
@@ -29,6 +29,12 @@ abstract final class FeatureFlags {
   /// Client-side isAdmin() remains as fast-path; server check is authoritative.
   /// Requires reso to deploy public.is_admin() SQL function before enabling.
   static const String adminServerVerify = 'admin_server_verify_enabled';
+
+  /// GH-59 / ADR-023: EscrowBadge on listing cards.
+  /// Gated so the backend migration (PR-B) can land ahead of the UI
+  /// rollout. Staged in Unleash: internal → 10% → 100%. Kill criterion:
+  /// checkout 409 rate > 2% OR badge accuracy complaint.
+  static const String listingsEscrowBadge = 'listings_escrow_badge';
 }
 
 /// Initialise Unleash feature flags in `main()` before `runApp`.

--- a/lib/features/home/presentation/widgets/home_data_view.dart
+++ b/lib/features/home/presentation/widgets/home_data_view.dart
@@ -14,8 +14,8 @@ import 'package:deelmarkt/widgets/trust/trust_banner.dart';
 import 'package:deelmarkt/features/home/presentation/home_notifier.dart';
 import 'package:deelmarkt/features/home/presentation/widgets/category_carousel.dart';
 import 'package:deelmarkt/features/home/presentation/widgets/home_sliver_app_bar.dart';
-import 'package:deelmarkt/widgets/cards/listing_deel_card.dart';
 import 'package:deelmarkt/features/home/presentation/widgets/section_header.dart';
+import 'package:deelmarkt/widgets/cards/escrow_aware_listing_card.dart';
 
 /// Height of the recent listings horizontal row.
 const _recentRowHeight = 280.0;
@@ -111,8 +111,8 @@ class HomeDataView extends ConsumerWidget {
         childAspectRatio: DeelCardTokens.gridChildAspectRatio,
         children: [
           for (final listing in data.nearby)
-            listingDeelCard(
-              listing,
+            EscrowAwareListingCard(
+              listing: listing,
               onTap:
                   () => context.goNamed(
                     'listing-detail',
@@ -164,8 +164,8 @@ class HomeDataView extends ConsumerWidget {
             final listing = data.recent[index];
             return SizedBox(
               width: _recentCardWidth,
-              child: listingDeelCard(
-                listing,
+              child: EscrowAwareListingCard(
+                listing: listing,
                 onTap:
                     () => context.goNamed(
                       'listing-detail',

--- a/lib/features/search/presentation/widgets/search_results_view.dart
+++ b/lib/features/search/presentation/widgets/search_results_view.dart
@@ -8,8 +8,8 @@ import 'package:deelmarkt/core/design_system/spacing.dart';
 import 'package:deelmarkt/features/search/domain/search_filter.dart';
 import 'package:deelmarkt/features/search/presentation/search_state.dart';
 import 'package:deelmarkt/widgets/cards/deel_card_tokens.dart';
+import 'package:deelmarkt/widgets/cards/escrow_aware_listing_card.dart';
 import 'package:deelmarkt/widgets/feedback/empty_state.dart';
-import 'package:deelmarkt/widgets/cards/listing_deel_card.dart';
 
 /// Search results grid with filter chips, result count, and infinite scroll.
 class SearchResultsView extends StatelessWidget {
@@ -117,8 +117,8 @@ class SearchResultsView extends StatelessWidget {
         childAspectRatio: DeelCardTokens.gridChildAspectRatio,
         children:
             data.listings.map((listing) {
-              return listingDeelCard(
-                listing,
+              return EscrowAwareListingCard(
+                listing: listing,
                 onTap: () => onListingTap(listing.id),
                 onFavouriteTap: () => onFavouriteTap(listing.id),
               );

--- a/lib/widgets/cards/escrow_aware_listing_card.dart
+++ b/lib/widgets/cards/escrow_aware_listing_card.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:deelmarkt/core/domain/entities/listing_entity.dart';
+import 'package:deelmarkt/core/services/unleash_service.dart';
+import 'package:deelmarkt/widgets/cards/listing_deel_card.dart';
+
+/// A [listingDeelCard] that reads `listing.isEscrowAvailable` and the
+/// Unleash flag [FeatureFlags.listingsEscrowBadge] to decide whether the
+/// escrow badge should render.
+///
+/// Introduced by GH-59 / ADR-023 so the badge is server-authoritative and
+/// gated by a progressive rollout flag, without changing the shared
+/// [listingDeelCard] signature (which already powers search, favourites
+/// and other non-badge surfaces).
+///
+/// Use this widget anywhere an entity-driven escrow badge is desired;
+/// keep [listingDeelCard] for surfaces that either always show the badge,
+/// never show it, or derive it from some other source.
+///
+/// Reference: docs/epics/E03-payments-escrow.md
+///            docs/adr/ADR-023-escrow-eligibility-authority.md
+class EscrowAwareListingCard extends ConsumerWidget {
+  const EscrowAwareListingCard({
+    required this.listing,
+    required this.onTap,
+    required this.onFavouriteTap,
+    super.key,
+  });
+
+  final ListingEntity listing;
+  final VoidCallback onTap;
+  final VoidCallback onFavouriteTap;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Badge visibility requires BOTH:
+    //   • The server-authoritative [ListingEntity.isEscrowAvailable] flag
+    //     (fail-closed default in the DTO → ADR-023).
+    //   • The Unleash flag [FeatureFlags.listingsEscrowBadge] (kill-switch
+    //     during the staged rollout).
+    final flagOn = ref.watch(
+      isFeatureEnabledProvider(FeatureFlags.listingsEscrowBadge),
+    );
+    return listingDeelCard(
+      listing,
+      onTap: onTap,
+      onFavouriteTap: onFavouriteTap,
+      showEscrowBadge: flagOn && listing.isEscrowAvailable,
+    );
+  }
+}

--- a/supabase/migrations/20260420160000_listings_with_favourites_expose_escrow_eligible.sql
+++ b/supabase/migrations/20260420160000_listings_with_favourites_expose_escrow_eligible.sql
@@ -1,0 +1,64 @@
+-- ──────────────────────────────────────────────────────────────────────────
+-- GH-59 / ADR-023 — Expose `listings.escrow_eligible` through the
+-- `listings_with_favourites` view.
+--
+-- Context (PR #185 review, mahmutkaya):
+--   Migration 20260420154314_listings_escrow_eligible.sql adds the column
+--   `listings.escrow_eligible`. The Dart data layer
+--   (supabase_listing_repository.dart, listing_dto.dart) reads the column
+--   from the `listings_with_favourites` view, NOT the base table. That view
+--   was last recreated on 2026-04-03 (20260403100000_r20_account_deletion_
+--   support.sql) with `SELECT l.* FROM listings l`.
+--
+--   PostgreSQL expands `l.*` to the concrete column list at CREATE VIEW
+--   time — columns added to the underlying table afterwards are NOT
+--   retroactively exposed through the view. Without this migration:
+--     • `SELECT escrow_eligible FROM listings_with_favourites` → error
+--     • The DTO's fail-closed parse returns `false` for every row
+--     • The EscrowAwareListingCard flag-gated render is never taken
+--     • The entire GH-59 feature ships silently non-functional in prod
+--       behind 100% unit coverage and a green SonarCloud gate.
+--
+--   This migration re-runs the same DROP + CREATE pattern from
+--   20260403100000 so `l.*` is re-expanded with the current column set,
+--   picking up `escrow_eligible` (plus any future columns added to
+--   `listings` before this migration is applied).
+--
+-- Rollback: paired `_down.sql` drops the view. Manual re-apply of
+--   20260403100000_r20 (or this migration) rebuilds it. See the down file
+--   for the ordered rollback sequence alongside
+--   20260420154315_listings_escrow_eligible_down.sql.
+-- ──────────────────────────────────────────────────────────────────────────
+
+-- Drop first because the view's column set is changing (new trailing
+-- `escrow_eligible` column). `CREATE OR REPLACE VIEW` cannot add columns
+-- without also reordering, and the safer explicit DROP matches the 2026-04-03
+-- convention for this view.
+DROP VIEW IF EXISTS listings_with_favourites;
+
+CREATE VIEW listings_with_favourites AS
+SELECT
+  l.*,
+  up.display_name AS seller_name,
+  up.avatar_url AS seller_avatar_url,
+  up.average_rating AS seller_rating,
+  up.kyc_level AS seller_kyc_level,
+  CASE
+    WHEN (SELECT auth.uid()) IS NULL THEN false
+    ELSE EXISTS(
+      SELECT 1 FROM favourites f
+      WHERE f.listing_id = l.id AND f.user_id = (SELECT auth.uid())
+    )
+  END AS is_favourited
+FROM listings l
+LEFT JOIN user_profiles up ON up.id = l.seller_id
+WHERE l.deleted_at IS NULL;
+
+GRANT SELECT ON listings_with_favourites TO authenticated, anon;
+
+COMMENT ON VIEW listings_with_favourites IS
+  'Listings joined with seller profile + per-user favourite flag. '
+  'Re-created on 2026-04-20 to pick up listings.escrow_eligible via l.*. '
+  'Re-running this DROP+CREATE after any listings column addition is the '
+  'canonical fix — ALTER TABLE ADD COLUMN does not propagate through the '
+  'view''s column list (PostgreSQL expands * at CREATE time).';

--- a/supabase/migrations/20260420160001_listings_with_favourites_expose_escrow_eligible_down.sql
+++ b/supabase/migrations/20260420160001_listings_with_favourites_expose_escrow_eligible_down.sql
@@ -1,0 +1,26 @@
+-- ──────────────────────────────────────────────────────────────────────────
+-- Paired rollback for
+-- 20260420160000_listings_with_favourites_expose_escrow_eligible.sql
+--
+-- Drops `listings_with_favourites` so the column drop in
+-- 20260420154315_listings_escrow_eligible_down.sql can succeed
+-- (PostgreSQL refuses to DROP COLUMN a view depends on).
+--
+-- Ordered rollback sequence when reverting GH-59 / ADR-023 end-to-end:
+--   1. Flip Unleash flag `listings_escrow_badge` → OFF (seconds kill).
+--   2. Apply this DOWN       — drops the view, releases the dependency.
+--   3. Apply 20260420154315  — drops triggers, functions, columns.
+--   4. Rebuild the view      — either re-apply 20260420160000 (which will
+--                              no longer include escrow_eligible because
+--                              step 3 dropped it) or re-run
+--                              20260403100000_r20 via `supabase db reset`.
+--
+-- This step-4 rebuild is explicit by design: a rollback that leaves the
+-- app without a listings query layer is unambiguous and paged, vs. a
+-- silently-broken partial view.
+--
+-- NOT auto-applied — commit path is manual via `supabase db push` against
+-- the target environment.
+-- ──────────────────────────────────────────────────────────────────────────
+
+DROP VIEW IF EXISTS listings_with_favourites;

--- a/test/features/home/presentation/home_screen_test.dart
+++ b/test/features/home/presentation/home_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:deelmarkt/core/design_system/theme.dart';
 import 'package:deelmarkt/core/services/repository_providers.dart';
 import 'package:deelmarkt/core/services/shared_prefs_provider.dart';
+import 'package:deelmarkt/core/services/unleash_service.dart';
 import 'package:deelmarkt/features/home/domain/entities/home_mode.dart';
 import 'package:deelmarkt/features/home/presentation/home_mode_notifier.dart';
 import 'package:deelmarkt/features/home/presentation/home_notifier.dart';
@@ -50,6 +51,10 @@ void main() {
           homeNotifierProvider.overrideWith(
             () => _NeverResolvingHomeNotifier(),
           ),
+          // GH-59: EscrowAwareListingCard reads this flag via Unleash.
+          isFeatureEnabledProvider(
+            FeatureFlags.listingsEscrowBadge,
+          ).overrideWith((ref) => false),
           ...extraOverrides,
         ],
         child: MaterialApp(

--- a/test/features/home/presentation/widgets/home_data_view_test.dart
+++ b/test/features/home/presentation/widgets/home_data_view_test.dart
@@ -7,6 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:deelmarkt/core/design_system/theme.dart';
 import 'package:deelmarkt/core/services/repository_providers.dart';
 import 'package:deelmarkt/core/services/shared_prefs_provider.dart';
+import 'package:deelmarkt/core/services/unleash_service.dart';
 import 'package:deelmarkt/features/home/presentation/home_notifier.dart';
 import 'package:deelmarkt/features/home/presentation/widgets/home_data_view.dart';
 import 'package:deelmarkt/features/home/presentation/widgets/home_mode_pill_switch.dart';
@@ -36,6 +37,11 @@ void main() {
           useMockDataProvider.overrideWithValue(true),
           sharedPreferencesProvider.overrideWithValue(prefs),
           homeNotifierProvider.overrideWith(() => _StubHomeNotifier(state)),
+          // GH-59: EscrowAwareListingCard reads the Unleash flag; override
+          // so widget tests don't call the real SDK.
+          isFeatureEnabledProvider(
+            FeatureFlags.listingsEscrowBadge,
+          ).overrideWith((ref) => false),
         ],
         child: MaterialApp(
           theme: theme ?? DeelmarktTheme.light,

--- a/test/features/search/presentation/widgets/search_results_view_test.dart
+++ b/test/features/search/presentation/widgets/search_results_view_test.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:deelmarkt/core/design_system/theme.dart';
+import 'package:deelmarkt/core/services/unleash_service.dart';
 import 'package:deelmarkt/features/home/domain/entities/listing_entity.dart';
 import 'package:deelmarkt/features/search/domain/search_filter.dart';
 import 'package:deelmarkt/features/search/presentation/search_state.dart';
@@ -23,15 +25,24 @@ final _testListing = ListingEntity(
 
 void main() {
   Widget buildView({required SearchState data}) {
-    return MaterialApp(
-      theme: DeelmarktTheme.light,
-      home: Scaffold(
-        body: SearchResultsView(
-          data: data,
-          onListingTap: (_) {},
-          onFavouriteTap: (_) {},
-          onLoadMore: () {},
-          onFilterTap: () {},
+    return ProviderScope(
+      overrides: [
+        // GH-59: EscrowAwareListingCard reads the Unleash flag — override
+        // it here so widget tests don't try to contact the real SDK.
+        isFeatureEnabledProvider(
+          FeatureFlags.listingsEscrowBadge,
+        ).overrideWith((ref) => false),
+      ],
+      child: MaterialApp(
+        theme: DeelmarktTheme.light,
+        home: Scaffold(
+          body: SearchResultsView(
+            data: data,
+            onListingTap: (_) {},
+            onFavouriteTap: (_) {},
+            onLoadMore: () {},
+            onFilterTap: () {},
+          ),
         ),
       ),
     );
@@ -94,19 +105,26 @@ void main() {
 
     testWidgets('renders with dark theme', (tester) async {
       await tester.pumpWidget(
-        MaterialApp(
-          theme: DeelmarktTheme.dark,
-          home: Scaffold(
-            body: SearchResultsView(
-              data: SearchState(
-                listings: [_testListing],
-                filter: const SearchFilter(query: 'test'),
-                total: 1,
+        ProviderScope(
+          overrides: [
+            isFeatureEnabledProvider(
+              FeatureFlags.listingsEscrowBadge,
+            ).overrideWith((ref) => false),
+          ],
+          child: MaterialApp(
+            theme: DeelmarktTheme.dark,
+            home: Scaffold(
+              body: SearchResultsView(
+                data: SearchState(
+                  listings: [_testListing],
+                  filter: const SearchFilter(query: 'test'),
+                  total: 1,
+                ),
+                onListingTap: (_) {},
+                onFavouriteTap: (_) {},
+                onLoadMore: () {},
+                onFilterTap: () {},
               ),
-              onListingTap: (_) {},
-              onFavouriteTap: (_) {},
-              onLoadMore: () {},
-              onFilterTap: () {},
             ),
           ),
         ),

--- a/test/widgets/cards/escrow_aware_listing_card_test.dart
+++ b/test/widgets/cards/escrow_aware_listing_card_test.dart
@@ -1,0 +1,107 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:deelmarkt/core/design_system/theme.dart';
+import 'package:deelmarkt/core/domain/entities/listing_entity.dart';
+import 'package:deelmarkt/core/services/unleash_service.dart';
+import 'package:deelmarkt/widgets/badges/deel_badge.dart';
+import 'package:deelmarkt/widgets/badges/deel_badge_data.dart';
+import 'package:deelmarkt/widgets/cards/escrow_aware_listing_card.dart';
+
+ListingEntity _listing({bool isEscrowAvailable = true}) => ListingEntity(
+  id: 'listing-1',
+  title: 'Vintage design stoel',
+  description: 'Een mooie vintage stoel',
+  priceInCents: 4500,
+  sellerId: 'seller-1',
+  sellerName: 'Jan de Vries',
+  condition: ListingCondition.good,
+  categoryId: 'cat-1',
+  imageUrls: const ['https://example.com/stoel.jpg'],
+  createdAt: DateTime(2026, 4, 20),
+  isEscrowAvailable: isEscrowAvailable,
+);
+
+Widget _host({required bool flagEnabled, required ListingEntity listing}) {
+  return EasyLocalization(
+    supportedLocales: const [Locale('nl', 'NL'), Locale('en', 'US')],
+    fallbackLocale: const Locale('en', 'US'),
+    path: 'assets/l10n',
+    child: ProviderScope(
+      overrides: [
+        isFeatureEnabledProvider(
+          FeatureFlags.listingsEscrowBadge,
+        ).overrideWith((ref) => flagEnabled),
+      ],
+      child: MaterialApp(
+        theme: DeelmarktTheme.light,
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: SizedBox(
+              width: 180,
+              child: EscrowAwareListingCard(
+                listing: listing,
+                onTap: () {},
+                onFavouriteTap: () {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    await EasyLocalization.ensureInitialized();
+  });
+
+  group('EscrowAwareListingCard', () {
+    testWidgets('hides badge when flag is OFF even if entity is eligible', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_host(flagEnabled: false, listing: _listing()));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(DeelBadge), findsNothing);
+    });
+
+    testWidgets('hides badge when flag is ON but entity is ineligible', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _host(flagEnabled: true, listing: _listing(isEscrowAvailable: false)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(DeelBadge), findsNothing);
+    });
+
+    testWidgets('shows badge only when flag ON AND entity eligible', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_host(flagEnabled: true, listing: _listing()));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(DeelBadge), findsOneWidget);
+      final badge = tester.widget<DeelBadge>(find.byType(DeelBadge));
+      expect(badge.type, DeelBadgeType.escrowProtected);
+    });
+
+    testWidgets('hides badge when both flag OFF and entity ineligible', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _host(flagEnabled: false, listing: _listing(isEscrowAvailable: false)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(DeelBadge), findsNothing);
+    });
+  });
+}

--- a/test/widgets/cards/escrow_aware_listing_card_test.dart
+++ b/test/widgets/cards/escrow_aware_listing_card_test.dart
@@ -69,6 +69,10 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(DeelBadge), findsNothing);
+      // Regression guard: the rest of the card must still render when the
+      // badge is suppressed — a silent `SizedBox.shrink()` would pass the
+      // `findsNothing` check above but break the listing grid entirely.
+      expect(find.text('Vintage design stoel'), findsOneWidget);
     });
 
     testWidgets('hides badge when flag is ON but entity is ineligible', (
@@ -80,6 +84,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(DeelBadge), findsNothing);
+      expect(find.text('Vintage design stoel'), findsOneWidget);
     });
 
     testWidgets('shows badge only when flag ON AND entity eligible', (

--- a/test/widgets/cards/escrow_aware_listing_card_test.dart
+++ b/test/widgets/cards/escrow_aware_listing_card_test.dart
@@ -15,7 +15,11 @@ ListingEntity _listing({bool isEscrowAvailable = true}) => ListingEntity(
   id: 'listing-1',
   title: 'Vintage design stoel',
   description: 'Een mooie vintage stoel',
-  priceInCents: 4500,
+  // Kept ≥ the migration's 5000-cent escrow threshold so the helper reads
+  // as self-consistent with `isEscrowAvailable: true`. The client does not
+  // re-derive eligibility from price (ADR-023 server-authoritative); this
+  // is purely for reader clarity — deelmarkt-dev L-1 / PR #184 review.
+  priceInCents: 10000,
   sellerId: 'seller-1',
   sellerName: 'Jan de Vries',
   condition: ListingCondition.good,


### PR DESCRIPTION
## Status: 🚧 DRAFT (unblocked — awaiting staging QA)

**PR [#183](https://github.com/deelmarkt-org/app/pull/183) (backend migration) is merged to `dev`.** This PR was rebased on top of `dev` and remains draft until the staging QA items below are signed off by reso.

## Summary

Frontend half of GitHub issue [#59](https://github.com/deelmarkt-org/app/issues/59) — renders the escrow badge on listing cards behind the `listings_escrow_badge` Unleash flag, driven by the server-authoritative `listing.isEscrowAvailable` field shipped in PR-B.

## What ships

### Widget `lib/widgets/cards/escrow_aware_listing_card.dart`

```dart
class EscrowAwareListingCard extends ConsumerWidget {
  @override
  Widget build(BuildContext context, WidgetRef ref) {
    final flagOn = ref.watch(
      isFeatureEnabledProvider(FeatureFlags.listingsEscrowBadge),
    );
    return listingDeelCard(
      listing,
      onTap: onTap,
      onFavouriteTap: onFavouriteTap,
      showEscrowBadge: flagOn && listing.isEscrowAvailable,
    );
  }
}
```

- `listingDeelCard` signature intentionally **unchanged** per the Senior Staff plan §D-3 — non-badge surfaces keep working.
- One-line caller swaps only: `home_data_view.dart` (×2) + `search_results_view.dart` (×1). Verified via `grep` that every non-test `listingDeelCard(` call now routes through the new widget.
- `ListingEntity` imported via `core/domain/entities/` barrel per CLAUDE.md §11 step 7 (cross-feature shared widget convention — Gemini false-positive rebutted and accepted).

### Feature flag constant

`FeatureFlags.listingsEscrowBadge = 'listings_escrow_badge'` — exact match with the server-side Unleash key (no string typos).

### Tests

- **NEW** `test/widgets/cards/escrow_aware_listing_card_test.dart` — 4 cases covering the full truth table (flag × entity). Asserts `DeelBadge.type == escrowProtected` in the positive case. Audit G-2 fix: negative cases also assert `find.text('Vintage design stoel') findsOneWidget` so a silent `SizedBox.shrink()` regression cannot pass. Uses `pumpAndSettle` so EasyLocalization resolves before assertions.
- **UPDATED** `home_screen_test`, `home_data_view_test`, `search_results_view_test` — `ProviderScope` overrides for `isFeatureEnabledProvider` so they don't contact the real Unleash SDK.

### Docs

- `FEATURE-FLAGS.md` — rollout log entry + kill criterion (checkout 409 rate > 2% OR badge accuracy complaint).
- `ADR-023` — status flipped to "Implementation in review"; `audit_log`→`audit_logs` typo fixed; dispute predicate explicitly deferred to E03 Phase 2.

## Tier-1 Audit

| Audit | Verdict | Fix Applied |
|-------|---------|-------------|
| Flutter review | APPROVE WITH FIX → RESOLVED | 🟡 `tester.pump()` → `tester.pumpAndSettle()` for EasyLocalization resolution |
| Security scan | CLEAN | No secrets, no dep change, route guards intact, flag spoofing mitigated by checkout 409 (ADR-023) |

## Test plan

- [x] `flutter analyze` — zero warnings on changed files (rebased on `dev`, re-verified)
- [x] `flutter test test/widgets/cards/escrow_aware_listing_card_test.dart test/features/home/presentation/widgets/home_data_view_test.dart` — all 9 pass
- [x] `dart run scripts/check_quality.dart` — all staged files clean
- [x] Pre-push hooks — all green (strict analyze + coverage + deployment drift)
- [ ] **STAGING** (reso): apply migration + seed eligible listing → verify badge appears
- [ ] **STAGING** (reso): flip seller KYC `level2`→`level0` → verify badge disappears in <1s
- [ ] **STAGING** (reso): Unleash flag OFF in prod → verify zero badge renders

## Ready-to-merge checklist

- [x] PR #183 merged to `dev`
- [x] PR-C rebased on `dev` — no conflicts
- [ ] Staging QA signs off on badge accuracy + KYC cascade timing (<1s)
- [ ] Legal sign-off per `FEATURE-FLAGS.md` governance (trust-signal >10% rollout rule)
- [ ] Flip this PR out of draft

## Tracked separately (post-merge, not blocking)

- **G-1** Verify `unleashUpdatesProvider.on('togglesUpdated')` invalidation <1s + Sentry integration (due at 10% canary)
- **G-3** "Canary diagnostics" runbook section in `FEATURE-FLAGS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
