### PR TITLE
docs(gh59): staging verification runbook + canary diagnostics

### DIFF
--- a/docs/FEATURE-FLAGS.md
+++ b/docs/FEATURE-FLAGS.md
@@ -39,7 +39,7 @@ Monitor these signals at each stage; hold ≥24h before advancing:
 | Checkout 409 rate (flag mismatch) | Supabase Edge Function `create-payment-intent` logs | <2% of escrow attempts | **>2% → flip OFF** |
 | Badge-accuracy Sentry events | Sentry project `deelmarkt-app`, tag `feature.listings_escrow_badge=on` | 0 user reports / 24h | **≥1 confirmed wrong badge → flip OFF** |
 | Unleash toggle-fetch failures | Sentry breadcrumb `unleash.fetch_failed` | <0.1% of sessions | **>1% for >10min → flip OFF** |
-| Cascade trigger p99 latency | Postgres `pg_stat_statements` for `trg_user_profiles_cascade_escrow` | <500ms | **>1s sustained → flip OFF, investigate** |
+| Cascade trigger p99 latency | Postgres `pg_stat_user_functions` rows for `trg_user_profiles_cascade_escrow` + `trg_listings_recompute_escrow` (requires `track_functions = 'pl'`). Fallback: `pg_stat_statements` filtered to the `UPDATE listings SET updated_at = now() WHERE seller_id = $1 ...` query text. | <500ms | **>1s sustained → flip OFF, investigate** |
 
 ### Kill-switch procedure (seconds)
 

--- a/docs/FEATURE-FLAGS.md
+++ b/docs/FEATURE-FLAGS.md
@@ -16,6 +16,47 @@
 |:-----|:-----|:-------|:---------|
 | `listings_escrow_badge` | 2026-04-17 | Registered, default OFF | pizmam |
 
+## Canary diagnostics
+
+> Applies to any flag that gates a **trust signal** (escrow, KYC, verified-seller).
+> Belengaz owns the rollout; pizmam owns the client instrumentation; reso owns
+> the server-side telemetry. All three must sign off before each rollout stage.
+
+### Before flipping to 10% canary
+
+- [ ] Staging QA runbook for the flag's feature has passed (e.g.
+  [`docs/runbooks/gh59-escrow-staging-verification.md`](runbooks/gh59-escrow-staging-verification.md)).
+- [ ] Sentry baseline captured for the last 24h: checkout 409 rate, listing
+  grid render errors, `isFeatureEnabledProvider` error count.
+- [ ] Legal sign-off recorded in the Rollout Log above (trust-signal flags).
+
+### During canary (10% → 50% → 100%)
+
+Monitor these signals at each stage; hold ≥24h before advancing:
+
+| Signal | Source | Threshold | Kill criterion |
+|:-------|:-------|:----------|:---------------|
+| Checkout 409 rate (flag mismatch) | Supabase Edge Function `create-payment-intent` logs | <2% of escrow attempts | **>2% → flip OFF** |
+| Badge-accuracy Sentry events | Sentry project `deelmarkt-app`, tag `feature.listings_escrow_badge=on` | 0 user reports / 24h | **≥1 confirmed wrong badge → flip OFF** |
+| Unleash toggle-fetch failures | Sentry breadcrumb `unleash.fetch_failed` | <0.1% of sessions | **>1% for >10min → flip OFF** |
+| Cascade trigger p99 latency | Postgres `pg_stat_statements` for `trg_user_profiles_cascade_escrow` | <500ms | **>1s sustained → flip OFF, investigate** |
+
+### Kill-switch procedure (seconds)
+
+1. Unleash admin console → target environment → flag → **OFF**.
+2. Post in `#product-trust` Slack with the rollout stage, trigger signal, and
+   Sentry link.
+3. File a fix-forward ticket (not a revert) — the server column is safe and
+   the client simply stops reading it.
+4. Re-enable only after root cause is fixed and staging QA re-passes.
+
+### After 100%
+
+- [ ] Close the linked GitHub issue (e.g. #59).
+- [ ] Mark the flag `REMOVE-ON: <date+90d>` in Active Flags.
+- [ ] Delete the flag (code + Unleash) after 90 days stable — stale trust-signal
+  flags are a latent compliance risk.
+
 ## Governance
 
 - All trust-signal flags (escrow, KYC badges, verification marks) require legal sign-off before exceeding 10% rollout. See `docs/COMPLIANCE.md`.

--- a/docs/runbooks/gh59-escrow-staging-verification.md
+++ b/docs/runbooks/gh59-escrow-staging-verification.md
@@ -8,7 +8,8 @@
 > **Owner:** reso (backend). Estimated wall-clock: **~15 minutes**.
 >
 > **References:**
-> - Migration: [`supabase/migrations/20260420154314_listings_escrow_eligible.sql`](../../supabase/migrations/20260420154314_listings_escrow_eligible.sql)
+> - Migration (column + triggers): [`supabase/migrations/20260420154314_listings_escrow_eligible.sql`](../../supabase/migrations/20260420154314_listings_escrow_eligible.sql)
+> - Migration (view passthrough): [`supabase/migrations/20260420160000_listings_with_favourites_expose_escrow_eligible.sql`](../../supabase/migrations/20260420160000_listings_with_favourites_expose_escrow_eligible.sql)
 > - ADR: [`docs/adr/ADR-023-escrow-eligibility-authority.md`](../adr/ADR-023-escrow-eligibility-authority.md)
 > - Flag registry: [`docs/FEATURE-FLAGS.md`](../FEATURE-FLAGS.md)
 
@@ -19,6 +20,50 @@
 - [ ] Staging build of the Flutter app pointed at staging Supabase.
 - [ ] Unleash admin console access for the staging instance.
 - [ ] Two terminal windows: one for `psql`, one for `stopwatch` timing.
+
+## Gate 0 — `listings_with_favourites` view exposes `escrow_eligible`
+
+**What this proves:** the view's column list actually includes the new
+`escrow_eligible` column. The Dart data layer
+([`lib/features/home/data/supabase/supabase_listing_repository.dart`](../../lib/features/home/data/supabase/supabase_listing_repository.dart))
+queries this view, not the base table. If the column is absent the DTO's
+fail-closed parse silently returns `false` for every row and the badge
+never renders — behind green CI.
+
+> **Why this gate exists.** PostgreSQL expands `SELECT l.*` inside a view to
+> the concrete column list **at CREATE VIEW time**. Migration
+> `20260420154314` adds `listings.escrow_eligible` but cannot retroactively
+> alter the view created on 2026-04-03. Migration
+> `20260420160000_listings_with_favourites_expose_escrow_eligible.sql`
+> re-snapshots the view; this gate asserts it was actually applied.
+
+```sql
+-- 0.1 Assert the view exposes the escrow_eligible column.
+SELECT column_name
+  FROM information_schema.columns
+ WHERE table_schema = 'public'
+   AND table_name   = 'listings_with_favourites'
+   AND column_name  = 'escrow_eligible';
+-- Expected: exactly one row returned.
+
+-- 0.2 Defence-in-depth: confirm the view actually returns the value
+--     for a real row (not merely that the column exists).
+SELECT id, escrow_eligible
+  FROM listings_with_favourites
+ LIMIT 1;
+-- Expected: a row with escrow_eligible = true OR false (never NULL for
+-- new rows; only pre-backfill rows could theoretically be NULL, and the
+-- backfill in 20260420154314 covered them).
+```
+
+**Pass criteria:**
+
+- [ ] Query 0.1 returns exactly one row.
+- [ ] Query 0.2 returns a value (true or false) — if it errors with
+  `column "escrow_eligible" does not exist`, the view migration did not
+  apply; stop and re-run `bash scripts/check_deployments.sh --deploy`.
+
+If Gate 0 fails, Gates 1-3 cannot pass. Fix before proceeding.
 
 ## Gate 1 — Badge appears on eligible listing after migration seed
 
@@ -53,6 +98,7 @@ INSERT INTO listings (
   true, false
 )
 RETURNING id, escrow_eligible;
+-- → save the returned id as :listing_id (used by the teardown step below).
 -- Expected: escrow_eligible = true  (set by trg_listings_escrow_eligible BEFORE INSERT)
 ```
 
@@ -124,8 +170,9 @@ This is the defence-in-depth layer that lets ops flip the kill switch in seconds
 
 **Steps (no SQL — this validates the Dart gate against prod Unleash):**
 
-1. Unleash admin console → environment **`prod`** → toggle `listings_escrow_badge`.
-   Confirm default state is **OFF** and matches [`docs/FEATURE-FLAGS.md`](../FEATURE-FLAGS.md).
+1. Unleash admin console → environment **`prod`** → **inspect** (do NOT flip)
+   the toggle `listings_escrow_badge`. Confirm current state is **OFF** and
+   matches [`docs/FEATURE-FLAGS.md`](../FEATURE-FLAGS.md).
 2. Install a **prod** build on a device (or run from a prod-pointed TestFlight
    lane). Do NOT use the staging build for this gate.
 3. Navigate to any listing known from logs to have `escrow_eligible = true`.
@@ -157,8 +204,18 @@ The migration is additive — no destructive rollback is required.
 - **Flag-level kill switch** (seconds): Unleash console → flip
   `listings_escrow_badge` to OFF. Server keeps computing `escrow_eligible`;
   the client simply stops reading it.
-- **Column-level rollback** (if a correctness issue in the trigger surfaces):
-  apply the paired down migration [`20260420154315_listings_escrow_eligible_down.sql`](../../supabase/migrations/20260420154315_listings_escrow_eligible_down.sql).
-  Drops happen in reverse-dependency order (cascade triggers → primary trigger
-  → function → index → columns). Zero data loss — the column value is reproducible
-  from the other gates any time the migration is re-applied.
+- **Column-level rollback** (if a correctness issue in the trigger surfaces),
+  ordered as:
+  1. Apply [`20260420160001_listings_with_favourites_expose_escrow_eligible_down.sql`](../../supabase/migrations/20260420160001_listings_with_favourites_expose_escrow_eligible_down.sql)
+     first — drops the view so the column drop below is not blocked by
+     dependency.
+  2. Apply [`20260420154315_listings_escrow_eligible_down.sql`](../../supabase/migrations/20260420154315_listings_escrow_eligible_down.sql) —
+     reverse-dependency drops (cascade triggers → primary trigger → function
+     → index → columns).
+  3. Rebuild the view: re-apply `20260420160000_listings_with_favourites_expose_escrow_eligible.sql`
+     (now without `escrow_eligible` in `l.*` because step 2 removed the
+     column). Until step 3 completes, the listings query layer returns no
+     rows — this is intentional and paged, not silent.
+
+  Zero data loss — the column value is reproducible from the other gates
+  any time the up migrations are re-applied.

--- a/docs/runbooks/gh59-escrow-staging-verification.md
+++ b/docs/runbooks/gh59-escrow-staging-verification.md
@@ -1,0 +1,164 @@
+# GH-59 / ADR-023 — Escrow Eligibility Staging Verification
+
+> **Purpose:** deterministic, reproducible verification of the three merge-gating
+> items on PR [#184](https://github.com/deelmarkt-org/app/pull/184). Run this
+> runbook against the **staging** Supabase + Unleash environment before removing
+> the draft flag.
+>
+> **Owner:** reso (backend). Estimated wall-clock: **~15 minutes**.
+>
+> **References:**
+> - Migration: [`supabase/migrations/20260420154314_listings_escrow_eligible.sql`](../../supabase/migrations/20260420154314_listings_escrow_eligible.sql)
+> - ADR: [`docs/adr/ADR-023-escrow-eligibility-authority.md`](../adr/ADR-023-escrow-eligibility-authority.md)
+> - Flag registry: [`docs/FEATURE-FLAGS.md`](../FEATURE-FLAGS.md)
+
+## Prerequisites
+
+- [ ] `psql` connected to the **staging** Supabase DB using the `service_role`
+  role. Anon role cannot UPDATE `user_profiles.kyc_level`.
+- [ ] Staging build of the Flutter app pointed at staging Supabase.
+- [ ] Unleash admin console access for the staging instance.
+- [ ] Two terminal windows: one for `psql`, one for `stopwatch` timing.
+
+## Gate 1 — Badge appears on eligible listing after migration seed
+
+**What this proves:** the `BEFORE INSERT` trigger writes `escrow_eligible = true`
+when all six inputs are satisfied, and the client renders the badge end-to-end.
+
+```sql
+-- 1.1 Pick a seller with kyc_level >= level1.
+SELECT id, kyc_level
+  FROM user_profiles
+ WHERE kyc_level <> 'level0'
+ LIMIT 1;
+-- → save as :seller_id
+
+-- 1.2 Pick an escrow-eligible category.
+SELECT id
+  FROM categories
+ WHERE escrow_eligible = true
+ LIMIT 1;
+-- → save as :category_id
+
+-- 1.3 Insert a listing that satisfies every gate.
+INSERT INTO listings (
+  seller_id, category_id,
+  title, description,
+  price_cents, quality_score,
+  is_active, is_sold
+) VALUES (
+  :'seller_id', :'category_id',
+  'QA: escrow eligible (delete me)', 'runbook seed',
+  6000, 75,
+  true, false
+)
+RETURNING id, escrow_eligible;
+-- Expected: escrow_eligible = true  (set by trg_listings_escrow_eligible BEFORE INSERT)
+```
+
+**Pass criteria:**
+
+- [ ] `RETURNING escrow_eligible` is `true`.
+- [ ] Staging app home grid shows the `DeelBadge(type: escrowProtected)` on
+  the seeded card within one pull-to-refresh.
+- [ ] Turning the Unleash flag `listings_escrow_badge` OFF and refreshing
+  removes the badge (proves the flag gate is live in staging too).
+
+**Teardown:**
+
+```sql
+DELETE FROM listings WHERE id = :'listing_id';
+```
+
+## Gate 2 — Badge disappears <1s after seller KYC downgrade
+
+**What this proves:** `trg_user_profiles_kyc_cascade` fires on the seller's
+`kyc_level` change, recomputes every row scoped by `seller_id`, and the UI
+observes the flip within the 1-second SLA promised to legal.
+
+```sql
+-- 2.1 Seed a second eligible listing (or reuse 1.3 if still present).
+--     Capture the current kyc_level so teardown can restore it.
+SELECT kyc_level FROM user_profiles WHERE id = :'seller_id';
+-- → save as :original_kyc
+
+-- 2.2 Start a timer.
+\timing on
+
+-- 2.3 Trigger the cascade.
+UPDATE user_profiles
+   SET kyc_level = 'level0'
+ WHERE id = :'seller_id';
+-- Expected: single UPDATE statement, duration reported by \timing.
+
+-- 2.4 Verify all seller listings flipped to false.
+SELECT id, escrow_eligible
+  FROM listings
+ WHERE seller_id = :'seller_id';
+-- Expected: every row escrow_eligible = false.
+
+\timing off
+```
+
+**Pass criteria:**
+
+- [ ] Cascade UPDATE completes in **<500ms** on a seller with <100 listings.
+  (SLA target is <1s total, leaving budget for Realtime push + UI rebuild.)
+- [ ] Staging app badge disappears within **1s** of the UPDATE commit —
+  confirmed either by Realtime subscription or a single pull-to-refresh.
+- [ ] `listings_with_favourites.escrow_eligible` column returns `false` for
+  every row of this seller (view inherits from `l.*`).
+
+**Teardown:**
+
+```sql
+UPDATE user_profiles SET kyc_level = :'original_kyc' WHERE id = :'seller_id';
+-- Cascade re-fires, flipping eligibility back where all other gates pass.
+```
+
+## Gate 3 — Flag OFF in prod → zero badge renders
+
+**What this proves:** even when the DB reports `escrow_eligible = true`, the
+client-side flag gate in `EscrowAwareListingCard.build()` suppresses the badge.
+This is the defence-in-depth layer that lets ops flip the kill switch in seconds.
+
+**Steps (no SQL — this validates the Dart gate against prod Unleash):**
+
+1. Unleash admin console → environment **`prod`** → toggle `listings_escrow_badge`.
+   Confirm default state is **OFF** and matches [`docs/FEATURE-FLAGS.md`](../FEATURE-FLAGS.md).
+2. Install a **prod** build on a device (or run from a prod-pointed TestFlight
+   lane). Do NOT use the staging build for this gate.
+3. Navigate to any listing known from logs to have `escrow_eligible = true`.
+
+**Pass criteria:**
+
+- [ ] Zero `DeelBadge(type: escrowProtected)` renders anywhere in the prod app.
+- [ ] Unleash `listings_escrow_badge` environment panel still shows `prod = OFF`
+  after the test (no accidental flip).
+
+> ⚠️ Do not flip the flag to ON in prod during this test. Production rollout is
+> a separate belengaz-owned operation documented in `docs/FEATURE-FLAGS.md`
+> §Canary diagnostics and gated by legal sign-off.
+
+## Sign-off
+
+Once all three gates pass:
+
+1. Tick the merge-gating checkboxes in PR [#184](https://github.com/deelmarkt-org/app/pull/184).
+2. Remove the DRAFT flag: `gh pr ready 184`.
+3. `deelmarkt-dev` already approved post-rebase — the merge button will enable.
+4. After merge, belengaz starts the staged Unleash rollout per
+   `docs/FEATURE-FLAGS.md` §Canary diagnostics.
+
+## Rollback
+
+The migration is additive — no destructive rollback is required.
+
+- **Flag-level kill switch** (seconds): Unleash console → flip
+  `listings_escrow_badge` to OFF. Server keeps computing `escrow_eligible`;
+  the client simply stops reading it.
+- **Column-level rollback** (if a correctness issue in the trigger surfaces):
+  apply the paired down migration [`20260420154315_listings_escrow_eligible_down.sql`](../../supabase/migrations/20260420154315_listings_escrow_eligible_down.sql).
+  Drops happen in reverse-dependency order (cascade triggers → primary trigger
+  → function → index → columns). Zero data loss — the column value is reproducible
+  from the other gates any time the migration is re-applied.


### PR DESCRIPTION
## Summary

Docs-only follow-up to unblock the three merge-gating items on PR [#184](https://github.com/deelmarkt-org/app/pull/184).

The gates require live Supabase staging + Unleash admin access that a contributor's worktree cannot have. Instead of leaving "run these manually" in the PR body, this adds a reproducible runbook plus the canary playbook that governs every rollout stage after merge.

## What ships

### `docs/runbooks/gh59-escrow-staging-verification.md` (new)

Deterministic, copy-paste `psql` snippets for the three gates:

| Gate | Proves | Wall-clock |
|:-----|:-------|:-----------|
| 1 — Badge appears on eligible seed | `BEFORE INSERT` trigger writes `escrow_eligible = true` end-to-end | ~5 min |
| 2 — Badge disappears <1s after KYC downgrade | `trg_user_profiles_kyc_cascade` fires + SLA holds | ~5 min |
| 3 — Flag OFF in prod → zero badge renders | Client-side `EscrowAwareListingCard` flag gate is live in prod | ~3 min |

Each gate has: prerequisites, exact SQL, expected outputs, pass criteria, and teardown. Sign-off section lists the two commands (`gh pr ready 184` + merge) needed to flip PR #184 out of draft.

### `docs/FEATURE-FLAGS.md` — new Canary diagnostics section

Applies to every trust-signal flag (escrow, KYC, verified-seller — not just `listings_escrow_badge`). Covers:

- **Pre-canary checklist** — staging QA passed, Sentry baseline captured, legal sign-off logged.
- **During-rollout kill-criteria table** — four signals (checkout 409 rate, badge-accuracy Sentry events, Unleash fetch failures, cascade trigger p99) with thresholds and automatic-OFF triggers.
- **Kill-switch procedure** — Unleash console flip, Slack notification, fix-forward ticket. Zero-rollback because migrations are additive.
- **Post-100% cleanup** — `REMOVE-ON` tag + 90-day flag deletion cycle so stale trust-signal flags don't become a latent compliance risk.

Covers ADR-023 §Rollback and the tracked-separately **G-3** item from PR #184.

## Senior Staff decisions

- **Integration test (`integration_test/escrow_cascade_test.dart`) DEFERRED.** Would be the first integration test in the repo — introducing local Supabase docker in CI is a precedent-setting infrastructure change that belongs in a dedicated planning cycle, not a verification-kit follow-up. The runbook SQL *is* the integration test; it's just manually invoked for now.
- **Sentry breadcrumb in `EscrowAwareListingCard` (G-1) DEFERRED.** Signal is only actionable at the 10% canary stage; no value adding instrumentation that logs zero events for days before it matters.
- **`docs/FEATURE-FLAGS.md` Active Flags / Rollout Log left untouched.** PR #184 (draft) already has edits to those sections; merging them here would stomp on that change. Added Canary section appears after the existing Rollout Log instead.

## Test plan

- [x] `git diff` — docs-only, no code or migration changes
- [x] Pre-commit hooks — all Dart/TS/migration gates skipped (no applicable files)
- [x] Pre-push hooks — all applicable gates passed, Dart-only gates skipped
- [x] Runbook cross-references verified: `supabase/migrations/20260420154315_listings_escrow_eligible_down.sql` exists in `dev`
- [ ] Reviewer spot-check: every SQL snippet in runbook Gate 1-2 uses only columns defined in [`supabase/migrations/20260420154314_listings_escrow_eligible.sql`](../blob/dev/supabase/migrations/20260420154314_listings_escrow_eligible.sql)

## Dependencies

- Built on `dev` as of `09edbb8` (post-#183 merge).
- **Does not** block PR #184. Merging this first just makes PR #184's staging QA easier for reso; they are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
