### PR TITLE
refactor(design-system): promote screen max-width magic numbers to Breakpoints constants (#201)

### DIFF
--- a/lib/core/design_system/breakpoints.dart
+++ b/lib/core/design_system/breakpoints.dart
@@ -18,6 +18,17 @@ class Breakpoints {
   /// Max content width for single-column layouts (onboarding, auth forms).
   static const double contentMaxWidth = 500;
 
+  /// Max width of the auth/gate card surface (login, register, suspension
+  /// gate). Matches the expanded-viewport card width specified in
+  /// `docs/screens/01-auth/02-registration.md` §Expanded,
+  /// `03-login.md`, and `06-suspension-gate.md`.
+  static const double authCardMaxWidth = 480;
+
+  /// Max width for single-column forms (review, review result, generic
+  /// [ResponsiveBody] default). Kept in sync with `ResponsiveBody`'s
+  /// default so there is one canonical form-column width.
+  static const double formMaxWidth = 600;
+
   static bool isCompact(BuildContext context) =>
       MediaQuery.sizeOf(context).width < compact;
 

--- a/lib/features/auth/presentation/screens/login_screen.dart
+++ b/lib/features/auth/presentation/screens/login_screen.dart
@@ -158,7 +158,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     return Scaffold(
       body: SafeArea(
         child: ResponsiveBody(
-          maxWidth: 480,
+          maxWidth: Breakpoints.authCardMaxWidth,
           child: SingleChildScrollView(child: content),
         ),
       ),

--- a/lib/features/auth/presentation/screens/register_screen.dart
+++ b/lib/features/auth/presentation/screens/register_screen.dart
@@ -51,7 +51,7 @@ class RegisterScreen extends ConsumerWidget {
       ),
       body: SafeArea(
         child: ResponsiveBody(
-          maxWidth: 480,
+          maxWidth: Breakpoints.authCardMaxWidth,
           child: _buildResponsiveContent(context, state),
         ),
       ),

--- a/lib/features/profile/presentation/screens/appeal_screen.dart
+++ b/lib/features/profile/presentation/screens/appeal_screen.dart
@@ -15,6 +15,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import 'package:deelmarkt/core/design_system/breakpoints.dart';
 import 'package:deelmarkt/core/design_system/colors.dart';
 import 'package:deelmarkt/core/design_system/spacing.dart';
 import 'package:deelmarkt/core/services/analytics/sanction_analytics.dart';
@@ -165,7 +166,7 @@ class _AppealScreenState extends ConsumerState<AppealScreen> {
         appBar: _buildAppBar(context, isSubmitting),
         body: SafeArea(
           child: ResponsiveBody(
-            maxWidth: 480,
+            maxWidth: Breakpoints.authCardMaxWidth,
             child: SingleChildScrollView(
               padding: const EdgeInsets.symmetric(horizontal: Spacing.s6),
               child: AppealFormBody(

--- a/lib/features/profile/presentation/screens/review_screen.dart
+++ b/lib/features/profile/presentation/screens/review_screen.dart
@@ -2,6 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:deelmarkt/core/design_system/breakpoints.dart';
 import 'package:deelmarkt/features/profile/presentation/notifiers/review_notifier.dart';
 import 'package:deelmarkt/features/profile/presentation/notifiers/review_screen_state.dart';
 import 'package:deelmarkt/features/profile/presentation/widgets/review_draft_form.dart';
@@ -32,11 +33,11 @@ class ReviewScreen extends ConsumerWidget {
       child: Scaffold(
         appBar: AppBar(title: Text('review.title'.tr())),
         body: SafeArea(
-          // maxWidth 500 matches docs/screens/07-profile/04-rating-review.md
-          // §Expanded; keeps the form readable and not stretched across desktop
-          // viewports.
+          // Breakpoints.contentMaxWidth (500px) matches
+          // docs/screens/07-profile/04-rating-review.md §Expanded; keeps the
+          // form readable and not stretched across desktop viewports.
           child: ResponsiveBody(
-            maxWidth: 500,
+            maxWidth: Breakpoints.contentMaxWidth,
             child: asyncState.when(
               loading: () => const Center(child: CircularProgressIndicator()),
               error:

--- a/lib/features/profile/presentation/screens/suspension_gate_screen.dart
+++ b/lib/features/profile/presentation/screens/suspension_gate_screen.dart
@@ -60,7 +60,7 @@ class SuspensionGateScreen extends ConsumerWidget {
         appBar: _buildAppBar(context, ref),
         body: SafeArea(
           child: ResponsiveBody(
-            maxWidth: 480,
+            maxWidth: Breakpoints.authCardMaxWidth,
             child: _buildResponsiveContent(context, ref, sanctionAsync),
           ),
         ),

--- a/lib/features/profile/presentation/widgets/review_draft_form.dart
+++ b/lib/features/profile/presentation/widgets/review_draft_form.dart
@@ -2,7 +2,6 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
-import 'package:deelmarkt/core/design_system/breakpoints.dart';
 import 'package:deelmarkt/core/design_system/colors.dart';
 import 'package:deelmarkt/core/design_system/spacing.dart';
 import 'package:deelmarkt/features/profile/presentation/notifiers/review_screen_state.dart';
@@ -72,12 +71,7 @@ class _ReviewDraftFormState extends State<ReviewDraftForm> {
         Expanded(
           child: SingleChildScrollView(
             padding: const EdgeInsets.all(Spacing.s4),
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(
-                maxWidth: Breakpoints.formMaxWidth,
-              ),
-              child: _buildFormBody(context, draft),
-            ),
+            child: _buildFormBody(context, draft),
           ),
         ),
         BottomAppBar(

--- a/lib/features/profile/presentation/widgets/review_draft_form.dart
+++ b/lib/features/profile/presentation/widgets/review_draft_form.dart
@@ -2,6 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
+import 'package:deelmarkt/core/design_system/breakpoints.dart';
 import 'package:deelmarkt/core/design_system/colors.dart';
 import 'package:deelmarkt/core/design_system/spacing.dart';
 import 'package:deelmarkt/features/profile/presentation/notifiers/review_screen_state.dart';
@@ -66,63 +67,16 @@ class _ReviewDraftFormState extends State<ReviewDraftForm> {
   @override
   Widget build(BuildContext context) {
     final draft = widget.draft;
-    final charCount = draft.body.length;
-    final counterColor = _counterColor(charCount);
-
     return Column(
       children: [
         Expanded(
           child: SingleChildScrollView(
             padding: const EdgeInsets.all(Spacing.s4),
             child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 600),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  if (draft.hasRestoredDraft) ...[
-                    TrustBanner.info(
-                      title: 'review.blind_review'.tr(),
-                      description: 'review.blind_explanation'.tr(),
-                      icon: PhosphorIcons.shield(PhosphorIconsStyle.fill),
-                    ),
-                    const SizedBox(height: Spacing.s4),
-                  ],
-                  Text(
-                    'review.how_was_experience'.tr(
-                      namedArgs: {'name': draft.revieweeName.tr()},
-                    ),
-                    style: Theme.of(context).textTheme.titleMedium,
-                  ),
-                  const SizedBox(height: Spacing.s4),
-                  RatingInput(
-                    value: draft.rating,
-                    onChanged: widget.onRatingChanged,
-                  ),
-                  const SizedBox(height: Spacing.s6),
-                  DeelInput(
-                    label: 'review.tell_about'.tr(),
-                    maxLines: 5,
-                    maxLength: 500,
-                    controller: _controller,
-                    onChanged: widget.onBodyChanged,
-                  ),
-                  const SizedBox(height: Spacing.s2),
-                  Align(
-                    alignment: Alignment.centerRight,
-                    child: Semantics(
-                      label: 'review.a11y.counter'.tr(),
-                      child: Text(
-                        'review.char_counter'.tr(
-                          namedArgs: {'current': '$charCount'},
-                        ),
-                        style: Theme.of(
-                          context,
-                        ).textTheme.bodySmall?.copyWith(color: counterColor),
-                      ),
-                    ),
-                  ),
-                ],
+              constraints: const BoxConstraints(
+                maxWidth: Breakpoints.formMaxWidth,
               ),
+              child: _buildFormBody(context, draft),
             ),
           ),
         ),
@@ -132,6 +86,53 @@ class _ReviewDraftFormState extends State<ReviewDraftForm> {
             child: FilledButton(
               onPressed: draft.canSubmit ? widget.onSubmit : null,
               child: Text('review.submit'.tr()),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildFormBody(BuildContext context, ReviewDraftState draft) {
+    final charCount = draft.body.length;
+    final counterColor = _counterColor(charCount);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (draft.hasRestoredDraft) ...[
+          TrustBanner.info(
+            title: 'review.blind_review'.tr(),
+            description: 'review.blind_explanation'.tr(),
+            icon: PhosphorIcons.shield(PhosphorIconsStyle.fill),
+          ),
+          const SizedBox(height: Spacing.s4),
+        ],
+        Text(
+          'review.how_was_experience'.tr(
+            namedArgs: {'name': draft.revieweeName.tr()},
+          ),
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        const SizedBox(height: Spacing.s4),
+        RatingInput(value: draft.rating, onChanged: widget.onRatingChanged),
+        const SizedBox(height: Spacing.s6),
+        DeelInput(
+          label: 'review.tell_about'.tr(),
+          maxLines: 5,
+          maxLength: 500,
+          controller: _controller,
+          onChanged: widget.onBodyChanged,
+        ),
+        const SizedBox(height: Spacing.s2),
+        Align(
+          alignment: Alignment.centerRight,
+          child: Semantics(
+            label: 'review.a11y.counter'.tr(),
+            child: Text(
+              'review.char_counter'.tr(namedArgs: {'current': '$charCount'}),
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall?.copyWith(color: counterColor),
             ),
           ),
         ),

--- a/lib/features/profile/presentation/widgets/review_result_view.dart
+++ b/lib/features/profile/presentation/widgets/review_result_view.dart
@@ -2,6 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
+import 'package:deelmarkt/core/design_system/breakpoints.dart';
 import 'package:deelmarkt/core/design_system/colors.dart';
 import 'package:deelmarkt/core/design_system/icon_sizes.dart';
 import 'package:deelmarkt/core/design_system/spacing.dart';
@@ -100,7 +101,7 @@ class ReviewBothVisibleView extends StatelessWidget {
     return SingleChildScrollView(
       padding: const EdgeInsets.all(Spacing.s4),
       child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 600),
+        constraints: const BoxConstraints(maxWidth: Breakpoints.formMaxWidth),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [

--- a/lib/features/profile/presentation/widgets/review_result_view.dart
+++ b/lib/features/profile/presentation/widgets/review_result_view.dart
@@ -2,7 +2,6 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
-import 'package:deelmarkt/core/design_system/breakpoints.dart';
 import 'package:deelmarkt/core/design_system/colors.dart';
 import 'package:deelmarkt/core/design_system/icon_sizes.dart';
 import 'package:deelmarkt/core/design_system/spacing.dart';
@@ -100,21 +99,18 @@ class ReviewBothVisibleView extends StatelessWidget {
   Widget build(BuildContext context) {
     return SingleChildScrollView(
       padding: const EdgeInsets.all(Spacing.s4),
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: Breakpoints.formMaxWidth),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              'review.both_visible'.tr(),
-              style: Theme.of(context).textTheme.titleMedium,
-            ),
-            const SizedBox(height: Spacing.s4),
-            ReviewCard(review: myReview),
-            const SizedBox(height: Spacing.s3),
-            ReviewCard(review: theirReview),
-          ],
-        ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'review.both_visible'.tr(),
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: Spacing.s4),
+          ReviewCard(review: myReview),
+          const SizedBox(height: Spacing.s3),
+          ReviewCard(review: theirReview),
+        ],
       ),
     );
   }

--- a/lib/features/transaction/presentation/screens/mollie_checkout_screen.dart
+++ b/lib/features/transaction/presentation/screens/mollie_checkout_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
+import 'package:deelmarkt/core/design_system/breakpoints.dart';
 import 'package:deelmarkt/core/design_system/colors.dart';
 import 'package:deelmarkt/core/design_system/spacing.dart';
 import 'package:deelmarkt/widgets/buttons/buttons.dart';
@@ -218,9 +219,10 @@ class _MollieCheckoutScreenState extends State<MollieCheckoutScreen> {
 enum MollieCheckoutResult { completed, cancelled }
 
 /// Layout frame for the Mollie checkout body — centers content and caps
-/// its width at 500px so the hosted iframe (~400px Mollie-controlled form)
-/// doesn't stretch on desktop. Extracted so the layout cap can be unit-
-/// tested without the `WebViewController` platform channel.
+/// its width at [Breakpoints.contentMaxWidth] (500px) so the hosted iframe
+/// (~400px Mollie-controlled form) doesn't stretch on desktop. Extracted
+/// so the layout cap can be unit-tested without the `WebViewController`
+/// platform channel.
 ///
 /// The cap is fixed (not a parameter): Mollie's form width is determined
 /// by Mollie, not by our design tokens, so there's no design-system
@@ -230,15 +232,15 @@ enum MollieCheckoutResult { completed, cancelled }
 class MollieCheckoutBodyFrame extends StatelessWidget {
   const MollieCheckoutBodyFrame({required this.child, super.key});
 
-  static const double _maxWidth = 500;
-
   final Widget child;
 
   @override
   Widget build(BuildContext context) {
     return Center(
       child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: _maxWidth),
+        constraints: const BoxConstraints(
+          maxWidth: Breakpoints.contentMaxWidth,
+        ),
         child: child,
       ),
     );

--- a/lib/widgets/layout/responsive_body.dart
+++ b/lib/widgets/layout/responsive_body.dart
@@ -10,9 +10,9 @@ import 'package:deelmarkt/core/design_system/spacing.dart';
 /// - expanded (≥840px): centered, max-width [maxWidth]
 ///
 /// Pick the constructor by screen class:
-/// - **Default [ResponsiveBody] (maxWidth 600)** — single-column flows:
-///   auth / onboarding / forms / settings / appeal / review. Caps content
-///   at a readable column width on desktop.
+/// - **Default [ResponsiveBody] (maxWidth [Breakpoints.formMaxWidth] = 600)**
+///   — single-column flows: auth / onboarding / forms / settings / appeal /
+///   review. Caps content at a readable column width on desktop.
 /// - **[ResponsiveBody.wide] (maxWidth 1200)** — multi-column dashboards:
 ///   home, search results, favourites, category browse. Caps content at
 ///   `Breakpoints.large` so grid cards keep reasonable proportions and
@@ -20,8 +20,11 @@ import 'package:deelmarkt/core/design_system/spacing.dart';
 ///
 /// Reference: docs/design-system/tokens.md §Breakpoints
 class ResponsiveBody extends StatelessWidget {
-  const ResponsiveBody({required this.child, this.maxWidth = 600, super.key})
-    : assert(maxWidth > 0, 'ResponsiveBody.maxWidth must be > 0');
+  const ResponsiveBody({
+    required this.child,
+    this.maxWidth = Breakpoints.formMaxWidth,
+    super.key,
+  }) : assert(maxWidth > 0, 'ResponsiveBody.maxWidth must be > 0');
 
   /// Dashboard-style cap for grid/catalogue screens. Defaults to
   /// [Breakpoints.large] (1200px) per tokens.md §Breakpoints.

--- a/test/core/design_system/breakpoints_test.dart
+++ b/test/core/design_system/breakpoints_test.dart
@@ -20,6 +20,14 @@ void main() {
     test('contentMaxWidth is 500', () {
       expect(Breakpoints.contentMaxWidth, 500);
     });
+
+    test('authCardMaxWidth is 480', () {
+      expect(Breakpoints.authCardMaxWidth, 480);
+    });
+
+    test('formMaxWidth is 600', () {
+      expect(Breakpoints.formMaxWidth, 600);
+    });
   });
 
   group('Breakpoints helpers', () {


### PR DESCRIPTION
Closes #201.

## Summary

Adds two named constants to `Breakpoints` and migrates 9 call sites that previously used raw `480` / `500` / `600` literals for `ResponsiveBody` and `ConstrainedBox` max-widths. **Values unchanged — no visual diff, no golden regeneration needed.**

## Scope expansion vs issue #201

Issue #201 enumerated 7 call sites, all in `lib/features/**/presentation/screens/**`. This PR extends that list to **9 call sites** by also migrating two widget files and one screen (explicit up-front declaration per review feedback):

| File | Added to scope because… |
|:-----|:------------------------|
| `lib/features/profile/presentation/screens/appeal_screen.dart` | Sibling of `suspension_gate_screen.dart` with the identical gate-card pattern. A spec change to the auth-card width should touch exactly one constant, not "3 screens in the issue list + 1 that wasn't named". |
| `lib/features/profile/presentation/widgets/review_draft_form.dart` | Form column width that must stay coherent with `ResponsiveBody` default. Left alone, the widget would hardcode `600` while every other form-column renderer now routes through `Breakpoints.formMaxWidth`. |
| `lib/features/profile/presentation/widgets/review_result_view.dart` | Same rationale as `review_draft_form.dart` — form-column cap that was the only remaining raw `600` in the profile feature. |

## What ships

### New constants (`lib/core/design_system/breakpoints.dart`)

| Constant | Value | Consumers |
|:---------|:------|:----------|
| `Breakpoints.authCardMaxWidth` | `480` | `login_screen`, `register_screen`, `suspension_gate_screen`, `appeal_screen` |
| `Breakpoints.formMaxWidth` | `600` | `ResponsiveBody` default (the two review widgets no longer constrain directly — see Round 2 below) |

### Reuse

`Breakpoints.contentMaxWidth = 500` gains its **first two consumers** (`review_screen`, `MollieCheckoutBodyFrame`). No longer dead code per the issue's observation.

### Incidental refactor — `ReviewDraftForm._buildFormBody`

The `dart format` multi-line wrap on the new `const BoxConstraints(maxWidth: Breakpoints.formMaxWidth)` pushed `ReviewDraftForm.build()` from 74 to 76 lines, tripping the SonarCloud cognitive-complexity hook (threshold 60). Extracted the scrollable form body to `_buildFormBody(context, draft)` — `build()` drops well under threshold.

> **Convention note for next time (per PR #204 review):** this extraction ideally belongs in its own commit so `git blame` separates "token extraction" from "method decomposition". Flagged for future token-promotion passes; not rebasing on an approved PR.

## Round 2 — post-approval fixes (commit `f9ccd0a`)

Gemini code-review surfaced a MEDIUM after the initial round: the two review widgets each wrap their body in a `ConstrainedBox(maxWidth: Breakpoints.formMaxWidth = 600)`, but `ReviewScreen` already wraps them in `ResponsiveBody(maxWidth: Breakpoints.contentMaxWidth = 500)` — strictly more restrictive, so the inner 600-px cap is never observable and leaks screen-class assumptions into shared widgets.

**Fix:** removed both inner `ConstrainedBox` wraps + now-unused `Breakpoints` imports. Verified via `grep` that the two widgets have a single callsite (`review_screen.dart`), so the removal can't regress another layout.

- `ReviewDraftForm._build` — inner ConstrainedBox gone; parent-provided `ResponsiveBody(500)` is the single source of width
- `ReviewBothVisibleView.build` — same refactor
- `Breakpoints.formMaxWidth` constant retained — still names the `ResponsiveBody` default and remains test-asserted in `breakpoints_test.dart`

## Rationale

CLAUDE.md §3.3 forbids magic layout values. Previously a spec change to the auth-card width would touch 4 screens; now it is one constant, enforced by `breakpoints_test.dart`.

## Test plan

- [x] `flutter analyze --no-pub` — zero warnings
- [x] `flutter test test/core/design_system test/features/auth test/features/profile test/widgets/layout` — **1128 tests passed**
- [x] `flutter test test/features/profile/presentation/widgets/review_*.dart` — 29 tests pass after Round 2 fix
- [x] `dart run scripts/check_quality.dart` — clean on all staged files
- [x] Pre-push hooks (format + analyze + coverage ≥80%) — all green
- [x] No raw `maxWidth: 480 / 500 / 600` literals remain in `lib/` layout call sites (verified via grep)
- [x] `MollieCheckoutBodyFrame` golden behaviour test still asserts `box.constraints.maxWidth == 500` (value unchanged)

## References

- CLAUDE.md §3.3 No Duplication Allowed
- Related issues: #192 (responsive foundation), #195 (PR #200 form wrapping), #198 (responsive rollout umbrella)
