### PR TITLE
feat(B): desktop polish — shipping trio + transaction-detail split (#206)

### DIFF
--- a/docs/screens/04-payments/03-transaction-detail.md
+++ b/docs/screens/04-payments/03-transaction-detail.md
@@ -11,7 +11,7 @@
 | Route | `/transactions/:id` |
 | Auth | Required |
 | States | Data (timeline varies by transaction status) — no loading/error (data passed as param) |
-| Responsive | No ResponsiveBody wrapper — should be added for web/tablet |
+| Responsive | ResponsiveBody wrapper (max 900px centered). Expanded ≥840px renders a two-column `Row` — main content (TrustBanner + AmountSection + ActionSection) on the left, EscrowTimeline pinned as a 320px right rail so it stays in view while scrolling. Compact stacks everything in a single column with the timeline at the top. See #206. |
 | Dark mode | Via Theme, but sub-widgets may have light-only colors |
 
 ## Current Layout (as implemented)
@@ -68,7 +68,7 @@ VARIATIONS: Light, Dark, Different transaction states:
 - "delivered" (confirm + dispute buttons)
 - "confirmed" (waiting for payout)
 - "released" (completed, payout done — green success state)
-Expanded desktop (add ResponsiveBody wrapper, centered max 600px)
+Expanded desktop (centered max 900px via ResponsiveBody, two-column `Row` — main content on left, 320px EscrowTimeline rail on right)
 ```
 
 ## Implementation Audit
@@ -80,7 +80,7 @@ Expanded desktop (add ResponsiveBody wrapper, centered max 600px)
 | Spacing from `Spacing` | PASS | `s4`, `s6` |
 | l10n keys | PASS | `transaction.status` via `.tr()` |
 | Semantics | PASS | Via sub-widgets (EscrowTrustBanner, AmountSection have Semantics) |
-| Responsive | **FAIL** | No `ResponsiveBody` wrapper — will be full-width on tablet/desktop |
+| Responsive | PASS | `ResponsiveBody(maxWidth: 900)` + two-column Row on expanded (see §Responsive above) |
 | Dark mode | PARTIAL | Depends on sub-widget dark mode support |
 | File length | PASS | 44 lines (very clean, delegates to sub-widgets) |
 
@@ -88,6 +88,6 @@ Expanded desktop (add ResponsiveBody wrapper, centered max 600px)
 
 | # | Severity | Issue |
 |---|----------|-------|
-| 1 | MEDIUM | No `ResponsiveBody` wrapper — screen stretches full-width on desktop. All 3 shipping screens use `ResponsiveBody`. |
+| 1 | RESOLVED | ~~No `ResponsiveBody` wrapper — screen stretches full-width on desktop.~~ Fixed by #195 (wrap) + #206 (maxWidth 900 + expanded two-column Row with timeline rail). |
 | 2 | MEDIUM | ActionSection buttons have `onPressed: null` — not wired to ConfirmDeliveryUseCase or dispute flow |
 | 3 | LOW | No loading/error states — data passed directly as constructor param. When ViewModels are added, will need `AsyncValue` handling. |

--- a/docs/screens/04-payments/03-transaction-detail.md
+++ b/docs/screens/04-payments/03-transaction-detail.md
@@ -80,7 +80,7 @@ Expanded desktop (centered max 900px via ResponsiveBody, single-column stack —
 | Spacing from `Spacing` | PASS | `s4`, `s6` |
 | l10n keys | PASS | `transaction.status` via `.tr()` |
 | Semantics | PASS | Via sub-widgets (EscrowTrustBanner, AmountSection have Semantics) |
-| Responsive | PASS | `ResponsiveBody(maxWidth: 900)` + two-column Row on expanded (see §Responsive above) |
+| Responsive | PASS | `ResponsiveBody(maxWidth: 900)`, single-column stack on all viewports. See #206 + #207. |
 | Dark mode | PARTIAL | Depends on sub-widget dark mode support |
 | File length | PASS | 44 lines (very clean, delegates to sub-widgets) |
 

--- a/docs/screens/04-payments/03-transaction-detail.md
+++ b/docs/screens/04-payments/03-transaction-detail.md
@@ -11,7 +11,7 @@
 | Route | `/transactions/:id` |
 | Auth | Required |
 | States | Data (timeline varies by transaction status) — no loading/error (data passed as param) |
-| Responsive | ResponsiveBody wrapper (max 900px centered). Expanded ≥840px renders a two-column `Row` — main content (TrustBanner + AmountSection + ActionSection) on the left, EscrowTimeline pinned as a 320px right rail so it stays in view while scrolling. Compact stacks everything in a single column with the timeline at the top. See #206. |
+| Responsive | ResponsiveBody wrapper (max 900px centered). Single-column stack on all viewports — the horizontal `EscrowTimeline` stepper needs ≥360px to render in its wide mode, so stacking below 900 keeps it readable rather than forcing a narrow vertical rail. See #206 + #207. |
 | Dark mode | Via Theme, but sub-widgets may have light-only colors |
 
 ## Current Layout (as implemented)
@@ -68,7 +68,7 @@ VARIATIONS: Light, Dark, Different transaction states:
 - "delivered" (confirm + dispute buttons)
 - "confirmed" (waiting for payout)
 - "released" (completed, payout done — green success state)
-Expanded desktop (centered max 900px via ResponsiveBody, two-column `Row` — main content on left, 320px EscrowTimeline rail on right)
+Expanded desktop (centered max 900px via ResponsiveBody, single-column stack — horizontal EscrowTimeline stepper stays in its wide mode at 900px cap)
 ```
 
 ## Implementation Audit
@@ -88,6 +88,6 @@ Expanded desktop (centered max 900px via ResponsiveBody, two-column `Row` — ma
 
 | # | Severity | Issue |
 |---|----------|-------|
-| 1 | RESOLVED | ~~No `ResponsiveBody` wrapper — screen stretches full-width on desktop.~~ Fixed by #195 (wrap) + #206 (maxWidth 900 + expanded two-column Row with timeline rail). |
+| 1 | RESOLVED | ~~No `ResponsiveBody` wrapper — screen stretches full-width on desktop.~~ Fixed by #195 (wrap) + #206/#207 (bump maxWidth to 900 so the horizontal EscrowTimeline stepper gets room to breathe on desktop). |
 | 2 | MEDIUM | ActionSection buttons have `onPressed: null` — not wired to ConfirmDeliveryUseCase or dispute flow |
 | 3 | LOW | No loading/error states — data passed directly as constructor param. When ViewModels are added, will need `AsyncValue` handling. |

--- a/docs/screens/05-shipping/01-shipping-qr.md
+++ b/docs/screens/05-shipping/01-shipping-qr.md
@@ -11,7 +11,7 @@
 | Route | `/shipping/:id/qr` |
 | Auth | Required |
 | States | Data (QR displayed) — no loading/error (data passed as constructor param) |
-| Responsive | ResponsiveBody wrapper (max 600px centered) |
+| Responsive | ResponsiveBody wrapper (max 800px centered — see #206 / PR #207, bumped from 600 so the QR card + instruction + CTA stack doesn't read cramped on tablet/desktop) |
 | Dark mode | Supported via theme |
 
 ## Current Layout (as implemented)
@@ -47,7 +47,7 @@ LAYOUT:
 CONTENT: PostNL label with tracking number "3SDEVC1234567", deadline 5 days out.
 
 VARIATIONS: Light, Dark, DHL carrier variant (different badge color/icon),
-Expanded desktop (centered max 600px via ResponsiveBody)
+Expanded desktop (centered max 800px via ResponsiveBody — QR card + instruction card + CTA stack needs more than 600px to breathe on tablet/desktop)
 ```
 
 ## Implementation Audit

--- a/docs/screens/05-shipping/02-tracking-timeline.md
+++ b/docs/screens/05-shipping/02-tracking-timeline.md
@@ -11,7 +11,7 @@
 | Route | `/shipping/:id/tracking` |
 | Auth | Required |
 | States | Data (events list), Empty (no updates yet) |
-| Responsive | ResponsiveBody wrapper (max 600px centered) |
+| Responsive | ResponsiveBody wrapper (max 800px centered — see #206 / PR #207, bumped from 600 so the vertical timeline + tracking-number card breathe on tablet/desktop) |
 | Dark mode | Supported via theme |
 
 ## Current Layout (as implemented)
@@ -53,7 +53,7 @@ CONTENT: 4 tracking events for a PostNL parcel: label created → dropped off �
 in transit → delivered. Show Dutch locations (Amsterdam, Sorteerdepot Nieuwegein).
 
 VARIATIONS: Light, Dark, Empty state (clock icon + "Nog geen updates"),
-Expanded desktop (centered max 600px), DHL carrier variant
+Expanded desktop (centered max 800px so the vertical timeline + tracking-number card breathe on wide viewports), DHL carrier variant
 ```
 
 ## Implementation Audit

--- a/lib/features/shipping/presentation/screens/shipping_detail_screen.dart
+++ b/lib/features/shipping/presentation/screens/shipping_detail_screen.dart
@@ -35,6 +35,9 @@ class ShippingDetailScreen extends StatelessWidget {
         child: SingleChildScrollView(
           padding: const EdgeInsets.symmetric(vertical: Spacing.s4),
           child: ResponsiveBody(
+            // Wider than the default form cap — matches the sibling shipping
+            // screens (QR, Tracking) for consistent hub-screen treatment.
+            maxWidth: 800,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [

--- a/lib/features/shipping/presentation/screens/shipping_qr_screen.dart
+++ b/lib/features/shipping/presentation/screens/shipping_qr_screen.dart
@@ -31,6 +31,10 @@ class ShippingQrScreen extends StatelessWidget {
         child: SingleChildScrollView(
           padding: const EdgeInsets.symmetric(vertical: Spacing.s4),
           child: ResponsiveBody(
+            // Wider than the default form cap — the QR card + instruction
+            // card + CTA stack reads cramped at 600px on tablet/desktop.
+            // See docs/screens/05-shipping/01-shipping-qr.md §Expanded.
+            maxWidth: 800,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [

--- a/lib/features/shipping/presentation/screens/tracking_screen.dart
+++ b/lib/features/shipping/presentation/screens/tracking_screen.dart
@@ -32,6 +32,10 @@ class TrackingScreen extends StatelessWidget {
         child: SingleChildScrollView(
           padding: const EdgeInsets.symmetric(vertical: Spacing.s4),
           child: ResponsiveBody(
+            // Wider than the default form cap — the vertical timeline
+            // + tracking number card breathe better at 800 on desktop.
+            // See docs/screens/05-shipping/02-tracking-timeline.md §Expanded.
+            maxWidth: 800,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [

--- a/lib/features/transaction/presentation/screens/transaction_detail_screen.dart
+++ b/lib/features/transaction/presentation/screens/transaction_detail_screen.dart
@@ -1,7 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 
-import 'package:deelmarkt/core/design_system/breakpoints.dart';
 import 'package:deelmarkt/core/design_system/spacing.dart';
 import 'package:deelmarkt/widgets/layout/responsive_body.dart';
 import 'package:deelmarkt/widgets/trust/escrow_timeline.dart';
@@ -14,20 +13,17 @@ import 'package:deelmarkt/features/transaction/presentation/widgets/escrow_step_
 
 /// Transaction detail screen — shows escrow timeline, amounts, and actions.
 ///
-/// - Compact (<840px): everything stacked in a single column (timeline
-///   renders at the top as the visual anchor, matching the mobile stitch
-///   designs in `docs/screens/04-payments/designs/`).
-/// - Expanded (≥840px): two-column `Row` — main content (TrustBanner +
-///   AmountSection + ActionSection) on the left, EscrowTimeline pinned as
-///   a 320px right rail so it stays in view while the user scrolls the
-///   main content.
+/// Single-column stack on all viewports; `ResponsiveBody` caps at 900px on
+/// expanded (≥840px) so the horizontal [EscrowTimeline] stepper renders in
+/// its wide mode (threshold 360px) instead of its phone-narrow fallback.
+/// A prior iteration of this PR (#206) tried a two-column `Row` with a
+/// 320px right rail — that forced the horizontal stepper into its narrow
+/// variant. Dropped per PR #207 review H-1.
 ///
-/// Reference: docs/screens/04-payments/03-transaction-detail.md §Expanded
+/// Reference: docs/screens/04-payments/03-transaction-detail.md
 /// Reference: docs/design-system/patterns.md §Escrow Timeline
 class TransactionDetailScreen extends StatelessWidget {
   const TransactionDetailScreen({required this.transaction, super.key});
-
-  static const double _timelineRailWidth = 320;
 
   final TransactionEntity transaction;
 
@@ -35,66 +31,37 @@ class TransactionDetailScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: Text('transaction.status'.tr())),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.symmetric(vertical: Spacing.s4),
-        child: ResponsiveBody(
-          maxWidth: 900,
-          child:
-              Breakpoints.isExpanded(context)
-                  ? _buildExpanded(context)
-                  : _buildCompact(context),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(vertical: Spacing.s4),
+          child: ResponsiveBody(
+            // Wider than the default form cap — the horizontal EscrowTimeline
+            // stepper reads better at 900px on tablet/desktop than at 600.
+            maxWidth: 900,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const TrustBanner.escrow(),
+                const SizedBox(height: Spacing.s6),
+                EscrowTimeline(
+                  currentStatus: transaction.status,
+                  escrowDeadline: transaction.escrowDeadline,
+                  onStepTapped:
+                      (step) => EscrowStepDetailSheet.show(
+                        context,
+                        step: step,
+                        transaction: transaction,
+                      ),
+                ),
+                const SizedBox(height: Spacing.s6),
+                AmountSection(transaction: transaction),
+                const SizedBox(height: Spacing.s6),
+                ActionSection(transaction: transaction),
+              ],
+            ),
+          ),
         ),
       ),
-    );
-  }
-
-  Widget _buildCompact(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const TrustBanner.escrow(),
-        const SizedBox(height: Spacing.s6),
-        _buildTimeline(context),
-        const SizedBox(height: Spacing.s6),
-        AmountSection(transaction: transaction),
-        const SizedBox(height: Spacing.s6),
-        ActionSection(transaction: transaction),
-      ],
-    );
-  }
-
-  Widget _buildExpanded(BuildContext context) {
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Expanded(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const TrustBanner.escrow(),
-              const SizedBox(height: Spacing.s6),
-              AmountSection(transaction: transaction),
-              const SizedBox(height: Spacing.s6),
-              ActionSection(transaction: transaction),
-            ],
-          ),
-        ),
-        const SizedBox(width: Spacing.s6),
-        SizedBox(width: _timelineRailWidth, child: _buildTimeline(context)),
-      ],
-    );
-  }
-
-  Widget _buildTimeline(BuildContext context) {
-    return EscrowTimeline(
-      currentStatus: transaction.status,
-      escrowDeadline: transaction.escrowDeadline,
-      onStepTapped:
-          (step) => EscrowStepDetailSheet.show(
-            context,
-            step: step,
-            transaction: transaction,
-          ),
     );
   }
 }

--- a/lib/features/transaction/presentation/screens/transaction_detail_screen.dart
+++ b/lib/features/transaction/presentation/screens/transaction_detail_screen.dart
@@ -1,6 +1,7 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 
+import 'package:deelmarkt/core/design_system/breakpoints.dart';
 import 'package:deelmarkt/core/design_system/spacing.dart';
 import 'package:deelmarkt/widgets/layout/responsive_body.dart';
 import 'package:deelmarkt/widgets/trust/escrow_timeline.dart';
@@ -13,10 +14,20 @@ import 'package:deelmarkt/features/transaction/presentation/widgets/escrow_step_
 
 /// Transaction detail screen — shows escrow timeline, amounts, and actions.
 ///
-/// Reference: docs/screens/04-payments/03-transaction-detail.md
+/// - Compact (<840px): everything stacked in a single column (timeline
+///   renders at the top as the visual anchor, matching the mobile stitch
+///   designs in `docs/screens/04-payments/designs/`).
+/// - Expanded (≥840px): two-column `Row` — main content (TrustBanner +
+///   AmountSection + ActionSection) on the left, EscrowTimeline pinned as
+///   a 320px right rail so it stays in view while the user scrolls the
+///   main content.
+///
+/// Reference: docs/screens/04-payments/03-transaction-detail.md §Expanded
 /// Reference: docs/design-system/patterns.md §Escrow Timeline
 class TransactionDetailScreen extends StatelessWidget {
   const TransactionDetailScreen({required this.transaction, super.key});
+
+  static const double _timelineRailWidth = 320;
 
   final TransactionEntity transaction;
 
@@ -27,21 +38,40 @@ class TransactionDetailScreen extends StatelessWidget {
       body: SingleChildScrollView(
         padding: const EdgeInsets.symmetric(vertical: Spacing.s4),
         child: ResponsiveBody(
+          maxWidth: 900,
+          child:
+              Breakpoints.isExpanded(context)
+                  ? _buildExpanded(context)
+                  : _buildCompact(context),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCompact(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const TrustBanner.escrow(),
+        const SizedBox(height: Spacing.s6),
+        _buildTimeline(context),
+        const SizedBox(height: Spacing.s6),
+        AmountSection(transaction: transaction),
+        const SizedBox(height: Spacing.s6),
+        ActionSection(transaction: transaction),
+      ],
+    );
+  }
+
+  Widget _buildExpanded(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               const TrustBanner.escrow(),
-              const SizedBox(height: Spacing.s6),
-              EscrowTimeline(
-                currentStatus: transaction.status,
-                escrowDeadline: transaction.escrowDeadline,
-                onStepTapped:
-                    (step) => EscrowStepDetailSheet.show(
-                      context,
-                      step: step,
-                      transaction: transaction,
-                    ),
-              ),
               const SizedBox(height: Spacing.s6),
               AmountSection(transaction: transaction),
               const SizedBox(height: Spacing.s6),
@@ -49,7 +79,22 @@ class TransactionDetailScreen extends StatelessWidget {
             ],
           ),
         ),
-      ),
+        const SizedBox(width: Spacing.s6),
+        SizedBox(width: _timelineRailWidth, child: _buildTimeline(context)),
+      ],
+    );
+  }
+
+  Widget _buildTimeline(BuildContext context) {
+    return EscrowTimeline(
+      currentStatus: transaction.status,
+      escrowDeadline: transaction.escrowDeadline,
+      onStepTapped:
+          (step) => EscrowStepDetailSheet.show(
+            context,
+            step: step,
+            transaction: transaction,
+          ),
     );
   }
 }

--- a/test/features/shipping/presentation/screens/tracking_screen_test.dart
+++ b/test/features/shipping/presentation/screens/tracking_screen_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:deelmarkt/features/shipping/domain/entities/shipping_label.dart';
+import 'package:deelmarkt/features/shipping/domain/entities/tracking_event.dart';
+import 'package:deelmarkt/features/shipping/presentation/screens/tracking_screen.dart';
+import 'package:deelmarkt/features/shipping/presentation/widgets/tracking_timeline.dart';
+import 'package:deelmarkt/widgets/layout/responsive_body.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+ShippingLabel _label() => ShippingLabel(
+  id: 'ship-001',
+  transactionId: 'txn-001',
+  qrData: '3SDEVC1234567|POSTNL|1012RR',
+  trackingNumber: '3SDEVC1234567',
+  carrier: ShippingCarrier.postnl,
+  destinationPostalCode: '1012RR',
+  shipByDeadline: DateTime(2026, 4, 12),
+  createdAt: DateTime(2026, 4, 8),
+);
+
+TrackingEvent _event() => TrackingEvent(
+  id: 'evt-1',
+  status: TrackingStatus.inTransit,
+  description: 'In transit',
+  location: 'Amsterdam',
+  timestamp: DateTime(2026, 4, 9, 10),
+);
+
+void main() {
+  group('TrackingScreen', () {
+    testWidgets('renders timeline when events present', (tester) async {
+      await pumpTestScreen(
+        tester,
+        TrackingScreen(label: _label(), events: [_event()]),
+      );
+      expect(find.byType(TrackingTimeline), findsOneWidget);
+    });
+
+    testWidgets('renders empty state when no events', (tester) async {
+      await pumpTestScreen(
+        tester,
+        TrackingScreen(label: _label(), events: const []),
+      );
+      expect(find.byType(TrackingTimeline), findsNothing);
+      expect(find.textContaining('tracking.noUpdates'), findsOneWidget);
+    });
+
+    testWidgets('caps content at 800px on expanded viewport — see #206', (
+      tester,
+    ) async {
+      tester.view.physicalSize = const Size(1400, 900);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await pumpTestScreen(
+        tester,
+        TrackingScreen(label: _label(), events: [_event()]),
+      );
+
+      final body = tester.widget<ResponsiveBody>(
+        find.descendant(
+          of: find.byType(TrackingScreen),
+          matching: find.byType(ResponsiveBody),
+        ),
+      );
+      expect(body.maxWidth, 800);
+    });
+  });
+}

--- a/test/features/transaction/presentation/screens/transaction_detail_screen_test.dart
+++ b/test/features/transaction/presentation/screens/transaction_detail_screen_test.dart
@@ -172,5 +172,53 @@ void main() {
 
       expect(find.byType(EscrowStepDetailSheet), findsOneWidget);
     });
+
+    testWidgets(
+      'caps content at 900px ResponsiveBody on expanded viewport — see #206',
+      (tester) async {
+        tester.view.physicalSize = const Size(1400, 900);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await pumpTestScreen(
+          tester,
+          TransactionDetailScreen(transaction: _buildTransaction()),
+        );
+
+        final body = tester.widget<ResponsiveBody>(
+          find.descendant(
+            of: find.byType(TransactionDetailScreen),
+            matching: find.byType(ResponsiveBody),
+          ),
+        );
+        expect(body.maxWidth, 900);
+      },
+    );
+
+    testWidgets(
+      'single-column stack on expanded — no top-level Row (regression pin '
+      'against the #206 rail variant that triggered EscrowTimeline narrow '
+      'fallback; see PR #207 H-1)',
+      (tester) async {
+        tester.view.physicalSize = const Size(1400, 900);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await pumpTestScreen(
+          tester,
+          TransactionDetailScreen(transaction: _buildTransaction()),
+        );
+
+        // Top-level layout inside ResponsiveBody is a Column, not a Row.
+        // Leaf widgets (AmountSection internals, TrustBanner) may contain
+        // their own Rows — only the immediate child matters here.
+        final topChild =
+            (tester.widget<ResponsiveBody>(find.byType(ResponsiveBody)).child)
+                as Column;
+        expect(topChild.children.length, greaterThanOrEqualTo(4));
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Belengaz-owned slice of **#196** (responsive rollout umbrella **#198**) — Payments + DevOps screens get meaningful desktop layouts. Pizmam's onboarding / profile / admin slice of #196 stays with the UI owner. Sub-issue **#206** tracks this split.

### Shipping trio — `ShippingQRScreen`, `TrackingScreen`, `ShippingDetailScreen`

Bump `ResponsiveBody maxWidth` 600 → 800. The QR card, vertical timeline, and tracking-number card stack read cramped at a 600px cap on tablet/desktop viewports; 800 restores the intended layout without bleeding onto wide desktop. Mobile (< compact breakpoint) unchanged.

### TransactionDetailScreen — desktop polish (revised after review)

Bump `ResponsiveBody maxWidth` 600 → 900 and add a `SafeArea` wrapper. **Single-column stack on all viewports** — the horizontal `EscrowTimeline` stepper needs ≥360px to render in its wide mode, so stacking below 900 keeps it readable.

> **Revised after Round 1 review (H-1):** An earlier commit on this branch (`fb7aedc`) tried a two-column Row on expanded — main content on the left + a 320px right rail for the timeline. Review flagged that the 320px width drops below `EscrowTimeline`'s own 360px narrow-mode threshold (`escrow_timeline.dart:31`), triggering its phone-narrow fallback on desktop (the opposite of "status anchor"). Reverted in `08554c8` per Option C. The 600→900 cap and the `SafeArea` addition remain; the two-column Row was dropped.

A follow-up could introduce a `VerticalEscrowTimeline` variant suited for a narrow rail — out of scope for this PR.

### Spec updates (CLAUDE.md §4.2 source-of-truth)

- [docs/screens/05-shipping/01-shipping-qr.md](docs/screens/05-shipping/01-shipping-qr.md) — 600 → 800 (landed in `3f554cc`).
- [docs/screens/05-shipping/02-tracking-timeline.md](docs/screens/05-shipping/02-tracking-timeline.md) — 600 → 800 (landed in `3f554cc`).
- [docs/screens/04-payments/03-transaction-detail.md](docs/screens/04-payments/03-transaction-detail.md) — documents 900 cap + single-column stack; the "Responsive: FAIL" audit row is marked RESOLVED with a cite to #195 + #206 / #207.

### Tests

- `tracking_screen_test.dart` — **NEW** per CLAUDE.md §6 `MISSING_TEST` rule. 3 cases: timeline present, empty state, viewport-pinned `ResponsiveBody.maxWidth == 800` at 1400×900.
- `transaction_detail_screen_test.dart` — 2 additional cases appended for the 900 cap + single-column regression pin (Round-1 H-2 coverage fix; SonarCloud now reports **100%** new-code coverage).

## What's NOT in scope

- Named `Breakpoints` constant for `800` / `900` — deferred to #201 (ongoing) or a follow-up. Inline comments explain each cap with a spec cite.
- `VerticalEscrowTimeline` variant — follow-up if product wants a genuinely-pinned status anchor on desktop.
- OnboardingScreen / OwnProfileScreen / PublicProfileScreen / SettingsScreen / AdminShellScreen — stay on pizmam's plate per CLAUDE.md §Developer Roles.

## Deployment impact

- **No Supabase migrations**, no Edge Function changes, no Mollie / PostNL / Cloudinary touchpoints. Pure UI layout work.
- `check_deployments.sh` clean.

## Test plan

- [x] `flutter analyze --fatal-infos` — clean.
- [x] `scripts/check_quality.dart --all` — clean.
- [x] 251 shipping + transaction unit tests pass (includes 3 new `tracking_screen_test` + 2 new `transaction_detail_screen_test` cases).
- [x] 246 screenshot drivers pass.
- [x] SonarCloud: **100%** new-code coverage.
- [ ] Verify in Chrome at 400 / 700 / 1000 / 1400 / 1800 px — shipping screens center at 800, transaction detail renders single-column at 900 cap.

## Commits

- `fb7aedc` — initial shipping 800 bump + transaction-detail two-column (reverted below).
- `08554c8` — Round-1 fixes: revert two-column (H-1/M-1/M-2); add regression-pin tests (H-2 coverage 61.9% → 100%); `SafeArea` wrap.
- `3f554cc` — **R2 M-1 fix:** ship the shipping spec docs (01-shipping-qr.md + 02-tracking-timeline.md) that earlier commit messages claimed but didn't actually land. Now in sync with the code's 800 cap per CLAUDE.md §4.2.

Closes #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
