### PR TITLE
feat(ui): cap home / favourites / category-detail at Breakpoints.large (#193 PR A)

### DIFF
--- a/lib/features/home/presentation/screens/category_detail_screen.dart
+++ b/lib/features/home/presentation/screens/category_detail_screen.dart
@@ -12,6 +12,7 @@ import 'package:deelmarkt/features/home/presentation/widgets/category_detail_loa
 import 'package:deelmarkt/features/home/presentation/widgets/featured_listings_grid.dart';
 import 'package:deelmarkt/features/home/presentation/widgets/subcategory_chip.dart';
 import 'package:deelmarkt/widgets/feedback/error_state.dart';
+import 'package:deelmarkt/widgets/layout/responsive_body.dart';
 
 /// Category detail screen — hero, subcategory chips, and featured listings.
 ///
@@ -73,61 +74,72 @@ class _DataView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return CustomScrollView(
-      slivers: [
-        // Hero section
+    // ResponsiveBody.wide caps the grid at Breakpoints.large (1200) on
+    // ultra-wide viewports. Each sliver owns its own horizontal padding
+    // (Spacing.s4), so the wrapper's padding is off (§193 PR A).
+    return ResponsiveBody.wide(
+      child: CustomScrollView(slivers: _buildSlivers(context)),
+    );
+  }
+
+  List<Widget> _buildSlivers(BuildContext context) {
+    return [
+      _heroSection(context),
+      if (state.subcategories.isNotEmpty)
         SliverToBoxAdapter(
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(
-              Spacing.s4,
-              Spacing.s4,
-              Spacing.s4,
-              Spacing.s6,
-            ),
+          child: _SubcategoryChips(subcategories: state.subcategories),
+        ),
+      if (state.featuredListings.isNotEmpty) ...[
+        _featuredHeader(context),
+        FeaturedListingsGrid(
+          listings: state.featuredListings,
+          onToggleFavourite: onToggleFavourite,
+        ),
+      ],
+      if (state.featuredListings.isEmpty && state.subcategories.isEmpty)
+        SliverFillRemaining(
+          child: Center(
             child: Text(
-              'category.heroTitle'.tr(args: [state.parent.name]),
-              style: Theme.of(context).textTheme.headlineMedium,
+              'category.empty'.tr(),
+              style: Theme.of(context).textTheme.bodyLarge,
             ),
           ),
         ),
-        // Subcategory chips
-        if (state.subcategories.isNotEmpty)
-          SliverToBoxAdapter(
-            child: _SubcategoryChips(subcategories: state.subcategories),
-          ),
-        // Featured listings header + grid
-        if (state.featuredListings.isNotEmpty) ...[
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(
-                Spacing.s4,
-                0,
-                Spacing.s4,
-                Spacing.s3,
-              ),
-              child: Text(
-                'category.recommendedIn'.tr(args: [state.parent.name]),
-                style: Theme.of(context).textTheme.labelLarge,
-              ),
-            ),
-          ),
-          FeaturedListingsGrid(
-            listings: state.featuredListings,
-            onToggleFavourite: onToggleFavourite,
-          ),
-        ],
-        // Empty state
-        if (state.featuredListings.isEmpty && state.subcategories.isEmpty)
-          SliverFillRemaining(
-            child: Center(
-              child: Text(
-                'category.empty'.tr(),
-                style: Theme.of(context).textTheme.bodyLarge,
-              ),
-            ),
-          ),
-        const SliverToBoxAdapter(child: SizedBox(height: Spacing.s8)),
-      ],
+      const SliverToBoxAdapter(child: SizedBox(height: Spacing.s8)),
+    ];
+  }
+
+  Widget _heroSection(BuildContext context) {
+    return SliverToBoxAdapter(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          Spacing.s4,
+          Spacing.s4,
+          Spacing.s4,
+          Spacing.s6,
+        ),
+        child: Text(
+          'category.heroTitle'.tr(args: [state.parent.name]),
+          style: Theme.of(context).textTheme.headlineMedium,
+        ),
+      ),
+    );
+  }
+
+  Widget _featuredHeader(BuildContext context) {
+    return SliverToBoxAdapter(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(
+          Spacing.s4,
+          0,
+          Spacing.s4,
+          Spacing.s3,
+        ),
+        child: Text(
+          'category.recommendedIn'.tr(args: [state.parent.name]),
+          style: Theme.of(context).textTheme.labelLarge,
+        ),
+      ),
     );
   }
 }

--- a/lib/features/home/presentation/screens/favourites_screen.dart
+++ b/lib/features/home/presentation/screens/favourites_screen.dart
@@ -14,6 +14,7 @@ import 'package:deelmarkt/widgets/cards/adaptive_listing_grid.dart';
 import 'package:deelmarkt/widgets/feedback/empty_state.dart';
 import 'package:deelmarkt/widgets/feedback/error_state.dart';
 import 'package:deelmarkt/widgets/feedback/skeleton_listing_card.dart';
+import 'package:deelmarkt/widgets/layout/responsive_body.dart';
 
 /// Favourites screen — P-28.
 ///
@@ -88,14 +89,16 @@ class _LoadingView extends StatelessWidget {
   Widget build(BuildContext context) {
     return Semantics(
       label: 'a11y.loading'.tr(),
-      child: CustomScrollView(
-        slivers: [
-          AdaptiveListingGrid(
-            padding: const EdgeInsets.all(Spacing.s4),
-            itemCount: 6,
-            itemBuilder: (_, _) => const SkeletonListingCard(),
-          ),
-        ],
+      child: ResponsiveBody.wide(
+        child: CustomScrollView(
+          slivers: [
+            AdaptiveListingGrid(
+              padding: const EdgeInsets.all(Spacing.s4),
+              itemCount: 6,
+              itemBuilder: (_, _) => const SkeletonListingCard(),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -116,42 +119,47 @@ class _DataView extends ConsumerWidget {
 
     return RefreshIndicator(
       onRefresh: () => ref.read(favouritesNotifierProvider.notifier).refresh(),
-      child: CustomScrollView(
-        slivers: [
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(
-                Spacing.s4,
-                Spacing.s4,
-                Spacing.s4,
-                Spacing.s2,
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'favourites.subtitle'.tr().toUpperCase(),
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: subtitleColor,
-                      letterSpacing: 1.2,
+      // ResponsiveBody.wide caps the grid at Breakpoints.large (1200) on
+      // ultra-wide viewports. Each sliver owns its own horizontal padding,
+      // so the wrapper's padding is off (§193 PR A).
+      child: ResponsiveBody.wide(
+        child: CustomScrollView(
+          slivers: [
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(
+                  Spacing.s4,
+                  Spacing.s4,
+                  Spacing.s4,
+                  Spacing.s2,
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'favourites.subtitle'.tr().toUpperCase(),
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: subtitleColor,
+                        letterSpacing: 1.2,
+                      ),
                     ),
-                  ),
-                  const SizedBox(height: Spacing.s1),
-                  Text(
-                    'favourites.savedItems'.tr(),
-                    style: Theme.of(context).textTheme.displayLarge,
-                  ),
-                ],
+                    const SizedBox(height: Spacing.s1),
+                    Text(
+                      'favourites.savedItems'.tr(),
+                      style: Theme.of(context).textTheme.displayLarge,
+                    ),
+                  ],
+                ),
               ),
             ),
-          ),
-          AdaptiveListingGrid(
-            padding: const EdgeInsets.all(Spacing.s4),
-            itemCount: listings.length,
-            itemBuilder:
-                (context, index) => FavouriteCard(listing: listings[index]),
-          ),
-        ],
+            AdaptiveListingGrid(
+              padding: const EdgeInsets.all(Spacing.s4),
+              itemCount: listings.length,
+              itemBuilder:
+                  (context, index) => FavouriteCard(listing: listings[index]),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/home/presentation/widgets/home_data_view.dart
+++ b/lib/features/home/presentation/widgets/home_data_view.dart
@@ -8,6 +8,7 @@ import 'package:deelmarkt/core/design_system/spacing.dart';
 import 'package:deelmarkt/core/router/routes.dart';
 import 'package:deelmarkt/widgets/cards/adaptive_listing_grid.dart';
 import 'package:deelmarkt/widgets/feedback/empty_state.dart';
+import 'package:deelmarkt/widgets/layout/responsive_body.dart';
 import 'package:deelmarkt/widgets/trust/trust_banner.dart';
 
 import 'package:deelmarkt/features/home/presentation/home_notifier.dart';
@@ -33,22 +34,28 @@ class HomeDataView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return RefreshIndicator(
       onRefresh: () => ref.read(homeNotifierProvider.notifier).refresh(),
-      child: CustomScrollView(
-        slivers: [
-          const HomeSliverAppBar(extraActions: [_BuyerAppBarActions()]),
-          if (data.categories.isNotEmpty) _categories(context),
-          _trustBanner(),
-          _nearbyHeader(context),
-          if (data.nearby.isNotEmpty)
-            _nearbyGrid(context, ref)
-          else
-            _nearbyEmpty(context),
-          if (data.recent.isNotEmpty) ...[
-            _recentHeader(context),
-            _recentRow(context, ref),
+      // ResponsiveBody.wide caps the scroll view at Breakpoints.large (1200)
+      // on ultra-wide viewports so the grid doesn't stretch edge-to-edge.
+      // Each sliver below owns its own horizontal padding (Spacing.s4), so
+      // the wrapper's padding is intentionally off (§193 PR A).
+      child: ResponsiveBody.wide(
+        child: CustomScrollView(
+          slivers: [
+            const HomeSliverAppBar(extraActions: [_BuyerAppBarActions()]),
+            if (data.categories.isNotEmpty) _categories(context),
+            _trustBanner(),
+            _nearbyHeader(context),
+            if (data.nearby.isNotEmpty)
+              _nearbyGrid(context, ref)
+            else
+              _nearbyEmpty(context),
+            if (data.recent.isNotEmpty) ...[
+              _recentHeader(context),
+              _recentRow(context, ref),
+            ],
+            const SliverPadding(padding: EdgeInsets.only(bottom: Spacing.s8)),
           ],
-          const SliverPadding(padding: EdgeInsets.only(bottom: Spacing.s8)),
-        ],
+        ),
       ),
     );
   }

--- a/lib/widgets/layout/responsive_body.dart
+++ b/lib/widgets/layout/responsive_body.dart
@@ -5,32 +5,46 @@ import 'package:deelmarkt/core/design_system/spacing.dart';
 
 /// Responsive body wrapper that constrains content for larger screens.
 ///
-/// - compact (<600px): full-width with mobile margins (16px)
-/// - medium (600–840px): full-width with tablet margins (24px)
+/// - compact (<600px): full-width
+/// - medium (600–840px): full-width
 /// - expanded (≥840px): centered, max-width [maxWidth]
 ///
-/// Pick the constructor by screen class:
-/// - **Default [ResponsiveBody] (maxWidth [Breakpoints.formMaxWidth] = 600)**
-///   — single-column flows: auth / onboarding / forms / settings / appeal /
-///   review. Caps content at a readable column width on desktop.
-/// - **[ResponsiveBody.wide] (maxWidth 1200)** — multi-column dashboards:
-///   home, search results, favourites, category browse. Caps content at
-///   `Breakpoints.large` so grid cards keep reasonable proportions and
-///   don't stretch edge-to-edge on ultra-wide viewports.
+/// Horizontal padding is applied *inside* the [maxWidth] cap when
+/// [addHorizontalPadding] is `true`: [Spacing.screenMarginMobile] (16) on
+/// compact and [Spacing.screenMarginTablet] (24) on medium+.
 ///
-/// Reference: docs/design-system/tokens.md §Breakpoints
+/// Pick the constructor by screen class:
+///
+/// - **Default [ResponsiveBody] (maxWidth [Breakpoints.formMaxWidth] = 600,
+///   padding on)** — single-column flows: auth / onboarding / forms /
+///   settings / appeal / review. The wrapper owns the horizontal screen
+///   margin so callers pass a plain child.
+/// - **[ResponsiveBody.wide] (maxWidth 1200, padding OFF)** — multi-column
+///   dashboards: home, search results, favourites, category browse, listing
+///   detail. Children are typically sliver trees (`CustomScrollView`) whose
+///   individual slivers (`AdaptiveListingGrid`, section headers, cards) own
+///   their own horizontal padding. Adding outer padding would double the
+///   margin and misalign cards relative to their headers, so the `.wide()`
+///   variant defaults to `addHorizontalPadding: false`. Pass `true`
+///   explicitly if the child does NOT manage its own horizontal margins.
+///
+/// Reference: docs/design-system/tokens.md §Breakpoints.
 class ResponsiveBody extends StatelessWidget {
   const ResponsiveBody({
     required this.child,
     this.maxWidth = Breakpoints.formMaxWidth,
+    this.addHorizontalPadding = true,
     super.key,
   }) : assert(maxWidth > 0, 'ResponsiveBody.maxWidth must be > 0');
 
   /// Dashboard-style cap for grid/catalogue screens. Defaults to
-  /// [Breakpoints.large] (1200px) per tokens.md §Breakpoints.
+  /// [Breakpoints.large] (1200px) per tokens.md §Breakpoints and **turns off
+  /// the wrapper's horizontal padding** because sliver-based dashboards own
+  /// their own margins. See class-level dartdoc for the rationale.
   const ResponsiveBody.wide({
     required this.child,
     this.maxWidth = Breakpoints.large,
+    this.addHorizontalPadding = false,
     super.key,
   }) : assert(maxWidth > 0, 'ResponsiveBody.maxWidth must be > 0');
 
@@ -39,21 +53,29 @@ class ResponsiveBody extends StatelessWidget {
   /// Max content width on expanded/large screens.
   final double maxWidth;
 
+  /// When `true` (the default form-column behaviour), the wrapper adds an
+  /// inner `Padding` of [Spacing.screenMarginMobile] / [Spacing.screenMarginTablet]
+  /// to provide the screen margin. When `false`, the caller (usually a
+  /// sliver tree) is responsible for its own horizontal padding.
+  final bool addHorizontalPadding;
+
   @override
   Widget build(BuildContext context) {
+    final capped = ConstrainedBox(
+      constraints: BoxConstraints(maxWidth: maxWidth),
+      child: addHorizontalPadding ? _padded(context, child) : child,
+    );
+    return Center(child: capped);
+  }
+
+  Widget _padded(BuildContext context, Widget inner) {
     final padding =
         Breakpoints.isCompact(context)
             ? Spacing.screenMarginMobile
             : Spacing.screenMarginTablet;
-
-    return Center(
-      child: ConstrainedBox(
-        constraints: BoxConstraints(maxWidth: maxWidth),
-        child: Padding(
-          padding: EdgeInsets.symmetric(horizontal: padding),
-          child: child,
-        ),
-      ),
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: padding),
+      child: inner,
     );
   }
 }

--- a/test/screenshots/_support/seed_data.dart
+++ b/test/screenshots/_support/seed_data.dart
@@ -27,6 +27,10 @@ const kScreenshotTransactionId = 'txn-001';
 /// Shipping order reference for the QR screen.
 const kScreenshotShipmentId = 'shipment-001';
 
+/// Category ID for category-detail screenshot (L1 electronics — populated
+/// with subcategories + featured listings in the mock category data).
+const kScreenshotCategoryId = 'cat-electronics';
+
 /// Locale variants to capture for each device × theme combination.
 const kScreenshotLocales = ['nl_NL', 'en_US'];
 

--- a/test/screenshots/drivers/category_detail_desktop_screenshot_test.dart
+++ b/test/screenshots/drivers/category_detail_desktop_screenshot_test.dart
@@ -1,0 +1,47 @@
+/// Screenshot driver — Category detail screen on desktop.
+///
+/// Captures the DESKTOP layout introduced in #193 PR A: content capped at
+/// [Breakpoints.large] (1200px) on ultra-wide viewports. Exercises the
+/// subcategory chips + featured-listings grid on a real L1 category
+/// (electronics) so the PNG reflects both hero content and card density.
+///
+/// Mobile coverage: `CategoryDetailScreen` widget tests in
+/// `test/features/home/presentation/screens/category_detail_screen_test.dart`
+/// cover compact layout invariants.
+///
+/// ### Scope — light theme only, for now
+///
+/// Dark-theme async-built screens trip the pre-existing `captureScreenshot`
+/// pre-paint-frame bug (see #203). Reintroduce
+/// `for (final theme in ScreenshotTheme.values)` once #203 lands.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:deelmarkt/features/home/presentation/screens/category_detail_screen.dart';
+
+import '../_support/device_frames.dart';
+import '../_support/screenshot_driver.dart';
+import '../_support/seed_data.dart';
+
+void main() {
+  setUpAll(initScreenshotEnvironment);
+
+  // Dark-theme goldens deliberately omitted per #203 — see library docstring.
+  for (final device in kScreenshotDesktopDevices) {
+    for (final locale in kScreenshotLocales) {
+      testWidgets('category_detail_desktop ${device.id} $locale light', (
+        tester,
+      ) async {
+        await captureScreenshot(
+          tester: tester,
+          screen: const CategoryDetailScreen(categoryId: kScreenshotCategoryId),
+          locale: locale,
+          theme: ScreenshotTheme.light,
+          device: device,
+          goldenName: 'category_detail_desktop',
+        );
+      });
+    }
+  }
+}

--- a/test/screenshots/drivers/favourites_desktop_screenshot_test.dart
+++ b/test/screenshots/drivers/favourites_desktop_screenshot_test.dart
@@ -1,0 +1,48 @@
+/// Screenshot driver — Favourites screen on desktop.
+///
+/// Captures the DESKTOP layout introduced in #193 PR A: content capped at
+/// [Breakpoints.large] (1200px) on ultra-wide viewports. Matches
+/// `docs/screens/03-listings/designs/favourites_desktop_expanded`.
+///
+/// Mobile coverage: `FavouritesScreen` widget tests in
+/// `test/features/home/presentation/screens/favourites_screen_test.dart`
+/// cover compact layout invariants; a mobile screenshot driver does not
+/// yet exist because the screen ships 2-col by default and is covered
+/// transitively by the widget tests.
+///
+/// ### Scope — light theme only, for now
+///
+/// Dark-theme async-built screens trip the pre-existing `captureScreenshot`
+/// pre-paint-frame bug (see #203). Reintroduce
+/// `for (final theme in ScreenshotTheme.values)` once #203 lands.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:deelmarkt/features/home/presentation/screens/favourites_screen.dart';
+
+import '../_support/device_frames.dart';
+import '../_support/screenshot_driver.dart';
+import '../_support/seed_data.dart';
+
+void main() {
+  setUpAll(initScreenshotEnvironment);
+
+  // Dark-theme goldens deliberately omitted per #203 — see library docstring.
+  for (final device in kScreenshotDesktopDevices) {
+    for (final locale in kScreenshotLocales) {
+      testWidgets('favourites_desktop ${device.id} $locale light', (
+        tester,
+      ) async {
+        await captureScreenshot(
+          tester: tester,
+          screen: const FavouritesScreen(),
+          locale: locale,
+          theme: ScreenshotTheme.light,
+          device: device,
+          goldenName: 'favourites_desktop',
+        );
+      });
+    }
+  }
+}

--- a/test/screenshots/drivers/home_buyer_desktop_screenshot_test.dart
+++ b/test/screenshots/drivers/home_buyer_desktop_screenshot_test.dart
@@ -1,0 +1,52 @@
+/// Screenshot driver — Home screen (buyer mode) on desktop.
+///
+/// Captures the DESKTOP layout introduced in #193 PR A: content capped at
+/// [Breakpoints.large] (1200px) on ultra-wide viewports. Matches
+/// `docs/screens/02-home/designs/home_desktop_light`.
+///
+/// Mobile coverage lives in `home_buyer_screenshot_test.dart` — unchanged.
+///
+/// ### Scope — light theme only, for now
+///
+/// Dark-theme async-built screens trip the pre-existing `captureScreenshot`
+/// pre-paint-frame bug (see #203). Evidence: on `dev`,
+/// `chat_thread_en_US_{light,dark}_android_phone` share blob `492a7ff0`
+/// because the dark path captures before `HomeDataView` paints. Light path
+/// is unaffected because shimmers and card colours on a light scaffold
+/// produce varied bytes even with early capture.
+///
+/// Reintroduce `for (final theme in ScreenshotTheme.values)` once #203
+/// lands the capture-infra fix.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:deelmarkt/core/services/repository_providers.dart';
+import 'package:deelmarkt/features/home/presentation/home_screen.dart';
+
+import '../_support/device_frames.dart';
+import '../_support/screenshot_driver.dart';
+import '../_support/seed_data.dart';
+
+void main() {
+  setUpAll(initScreenshotEnvironment);
+
+  // Dark-theme goldens deliberately omitted per #203 — see library docstring.
+  for (final device in kScreenshotDesktopDevices) {
+    for (final locale in kScreenshotLocales) {
+      testWidgets('home_buyer_desktop ${device.id} $locale light', (
+        tester,
+      ) async {
+        await captureScreenshot(
+          tester: tester,
+          screen: const HomeScreen(),
+          locale: locale,
+          theme: ScreenshotTheme.light,
+          device: device,
+          goldenName: 'home_buyer_desktop',
+          extraOverrides: [currentUserProvider.overrideWithValue(null)],
+        );
+      });
+    }
+  }
+}

--- a/test/widgets/layout/responsive_body_test.dart
+++ b/test/widgets/layout/responsive_body_test.dart
@@ -131,5 +131,99 @@ void main() {
       );
       expect(box.constraints.maxWidth, 1000);
     });
+
+    testWidgets('wide constructor omits horizontal padding by default '
+        '(callers own margins)', (tester) async {
+      await tester.pumpWidget(
+        const MediaQuery(
+          data: MediaQueryData(size: Size(1600, 900)),
+          child: MaterialApp(
+            home: Scaffold(body: ResponsiveBody.wide(child: Text('Wide'))),
+          ),
+        ),
+      );
+      expect(
+        find.descendant(
+          of: find.byType(ResponsiveBody),
+          matching: find.byType(Padding),
+        ),
+        findsNothing,
+      );
+    });
+
+    testWidgets(
+      'wide constructor adds padding when addHorizontalPadding: true',
+      (tester) async {
+        await tester.pumpWidget(
+          const MediaQuery(
+            data: MediaQueryData(size: Size(1600, 900)),
+            child: MaterialApp(
+              home: Scaffold(
+                body: ResponsiveBody.wide(
+                  addHorizontalPadding: true,
+                  child: Text('Wide'),
+                ),
+              ),
+            ),
+          ),
+        );
+        expect(
+          find.descendant(
+            of: find.byType(ResponsiveBody),
+            matching: find.byType(Padding),
+          ),
+          findsOneWidget,
+        );
+      },
+    );
+  });
+
+  group('ResponsiveBody addHorizontalPadding flag', () {
+    testWidgets(
+      'default ResponsiveBody(…) keeps horizontal padding (regression pin)',
+      (tester) async {
+        await tester.pumpWidget(
+          const MediaQuery(
+            data: MediaQueryData(size: Size(375, 800)),
+            child: MaterialApp(
+              home: Scaffold(body: ResponsiveBody(child: Text('Form'))),
+            ),
+          ),
+        );
+        expect(
+          find.descendant(
+            of: find.byType(ResponsiveBody),
+            matching: find.byType(Padding),
+          ),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'ResponsiveBody(…) drops padding when addHorizontalPadding: false',
+      (tester) async {
+        await tester.pumpWidget(
+          const MediaQuery(
+            data: MediaQueryData(size: Size(375, 800)),
+            child: MaterialApp(
+              home: Scaffold(
+                body: ResponsiveBody(
+                  addHorizontalPadding: false,
+                  child: Text('Form'),
+                ),
+              ),
+            ),
+          ),
+        );
+        expect(
+          find.descendant(
+            of: find.byType(ResponsiveBody),
+            matching: find.byType(Padding),
+          ),
+          findsNothing,
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
Closes part of #193 (PR A slice). Depends on #192 shipped via PR #199.

## Summary

Wraps the three buyer-discovery screens whose grids already adapt columns via `AdaptiveListingGrid` in `ResponsiveBody.wide` so content caps at `Breakpoints.large` (1200 px) on ultra-wide viewports. **No grid logic change; compact and medium layouts render identically — mobile goldens unchanged.**

This is the first of three slices per the approved #193 plan:

| Slice | Branch | Status |
|:-----|:-------|:-------|
| **PR A — width caps** (this) | `feature/pizmam-E01-desktop-width-caps` | this PR |
| PR B — category-browse 2-col grid | `feature/pizmam-E01-category-browse-grid` | in flight |
| PR C — search filter sidebar | `feature/pizmam-E01-search-filter-sidebar` | queued |

## Scope refinement vs issue #193

The issue body contained two claims that are **already obsolete on `dev`** (fixed during #192 roll-out):

| Issue claim | Current state on `dev` | Action in this PR |
|:------------|:-----------------------|:-----------------|
| `FavouritesScreen` hardcodes `crossAxisCount: 2` | Already uses `AdaptiveListingGrid` ([`favourites_screen.dart:148`](lib/features/home/presentation/screens/favourites_screen.dart#L148)) | No grid change; only width cap added |
| `FavouriteCard` hardcodes `0.65` aspect ratio | Already delegates to `DeelCardTokens.gridChildAspectRatio` via `DeelCard.grid` | No aspect-ratio change |

Flagged up-front rather than buried in a diff-audit, per PR #204 Round-2 convention.

## Primitive change — `ResponsiveBody.addHorizontalPadding`

The issue specifies wrapping screens in `ResponsiveBody.wide`, but the current `ResponsiveBody` always adds inner `Padding` of `Spacing.screenMarginMobile` (16) / `screenMarginTablet` (24). The three screens in scope already have their own per-sliver horizontal padding via `AdaptiveListingGrid`, section headers, trust banner, and `_recentRow`. Layering the wrapper's outer padding on top would:

- **Double** the horizontal margin on compact: 16 (wrapper) + 16 (grid) = 32 px.
- **Quadruple** it on tablet vs today: 24 (wrapper) + 16 (grid) = 40 px vs today's 16.
- **Misalign** cards with section headers (which already carry `EdgeInsets.only(bottom: Spacing.s3)` — no horizontal).

**Fix:** `ResponsiveBody` gains an `addHorizontalPadding` field:

- Default ctor `ResponsiveBody(…)` → `addHorizontalPadding: true` (preserves form-column behaviour — auth / onboarding / settings / review / appeal / suspension).
- `ResponsiveBody.wide(…)` → `addHorizontalPadding: false` (sliver dashboards own their margins; wrapper only caps width).

Backward compatible — `ResponsiveBody.wide` has **zero consumers** on `dev` before this PR, so no breakage risk. Opt-in: pass `addHorizontalPadding: true` on `.wide()` if a future caller needs wrapper-managed padding.

## Screen wraps

| File | Change |
|:-----|:-------|
| [`home_data_view.dart`](lib/features/home/presentation/widgets/home_data_view.dart) | Wrap `CustomScrollView` in `ResponsiveBody.wide` |
| [`favourites_screen.dart`](lib/features/home/presentation/screens/favourites_screen.dart) | Wrap both `_DataView` and `_LoadingView` scroll views in `ResponsiveBody.wide` so loading → data transitions don't reflow |
| [`category_detail_screen.dart`](lib/features/home/presentation/screens/category_detail_screen.dart) | Wrap `_DataView.build` scroll view in `ResponsiveBody.wide`; extract `_buildSlivers` / `_heroSection` / `_featuredHeader` helpers to keep `build()` under the 60-line SonarCloud cognitive-complexity budget. `FeaturedListingsGrid` deletion deferred to PR C per plan. |

## Screenshot goldens — light-only per #203

3 new desktop-only drivers at `kScreenshotDesktopDevices`:

- `test/screenshots/drivers/home_buyer_desktop_screenshot_test.dart`
- `test/screenshots/drivers/favourites_desktop_screenshot_test.dart`
- `test/screenshots/drivers/category_detail_desktop_screenshot_test.dart`

All iterate `[ScreenshotTheme.light]` only (hardcoded, not `ScreenshotTheme.values`) per the pre-existing `captureScreenshot` pre-paint bug tracked in **#203**. Evidence: on `dev`, `chat_thread_en_US_{light,dark}_android_phone` share blob `492a7ff0` because the dark path captures before async builders paint. Each driver's library docstring documents the deferral and the plan to reintroduce `ScreenshotTheme.values` once #203 lands.

`kScreenshotCategoryId = 'cat-electronics'` added to `seed_data.dart` so `CategoryDetailScreen` renders both subcategory chips and featured listings in the PNG.

## Test plan

- [x] `flutter analyze --no-pub` — zero warnings
- [x] `flutter test test/features/home test/widgets/layout` — **401 tests pass**
- [x] `flutter test test/widgets/layout/responsive_body_test.dart` — **12/12 pass** including 4 new padding-flag cases (both ctors × both flag values)
- [x] `flutter test test/features/home/presentation/screens/category_detail_screen_test.dart` — **7/7 pass** after helper extraction
- [x] `dart run scripts/check_quality.dart` — clean
- [x] Pre-commit + pre-push hooks — all green (format / analyze / coverage / SonarCloud proxy)
- [x] Desktop drivers pump cleanly on Windows (6 new test cases)
- [ ] `macos-14` CI generates and commits the 6 new PNGs (`home_buyer_desktop`, `favourites_desktop`, `category_detail_desktop` × 2 locales)

## Acceptance criteria (partial — this slice)

- [x] Home / favourites / category-detail cap content at `Breakpoints.large` (1200 px) on ultra-wide viewports.
- [x] No regression in compact layout (existing mobile goldens untouched — `ResponsiveBody.wide` is a no-op under 1200 because content width < 1200).
- [x] `scripts/check_quality.dart --all` clean; line budgets respected.
- [ ] PR B (category-browse 2-col grid) — in flight on separate branch.
- [ ] PR C (search filter sidebar + `FeaturedListingsGrid` cleanup) — queued.

## References

- Issue: #193
- Umbrella epic: #198
- Foundation: #192 (PR #199 — `ResponsiveBody.wide`, `AdaptiveListingGrid`, `Breakpoints.large`)
- Sibling capture-bug tracker: #203 (dark-theme async-build goldens)
- Designs: [`home_desktop_light`](docs/screens/02-home/designs/home_desktop_light), [`favourites_desktop_expanded`](docs/screens/03-listings/designs/favourites_desktop_expanded)
- Owner: **pizmam** (per CLAUDE.md §Developer Roles)
