### PR TITLE
refactor(design-system): make AdaptiveListingGrid container-aware via SliverLayoutBuilder (#193 PR D)

### DIFF
--- a/lib/core/design_system/breakpoints.dart
+++ b/lib/core/design_system/breakpoints.dart
@@ -29,6 +29,10 @@ class Breakpoints {
   /// default so there is one canonical form-column width.
   static const double formMaxWidth = 600;
 
+  /// Width of the search-filter sidebar on expanded viewports.
+  /// Reference: docs/screens/02-home/03-search.md §Responsive.
+  static const double filterSidebarWidth = 240;
+
   static bool isCompact(BuildContext context) =>
       MediaQuery.sizeOf(context).width < compact;
 
@@ -44,24 +48,35 @@ class Breakpoints {
   static bool isLarge(BuildContext context) =>
       MediaQuery.sizeOf(context).width >= large;
 
-  /// Width of the search-filter sidebar on expanded viewports.
-  /// Reference: docs/screens/02-home/03-search.md §Responsive.
-  static const double filterSidebarWidth = 240;
-
-  /// Listing-grid column count for the current viewport.
+  /// Listing-grid column count for the current **viewport**.
+  ///
+  /// Prefer [gridColumnsForContainerWidth] in grids that may render inside
+  /// a constrained container (sidebar-adjacent panes, width-capped scroll
+  /// views) — viewport width and container width diverge in those cases,
+  /// and using viewport width produces too-dense layouts that overflow
+  /// card contents.
+  ///
   /// Reference: docs/design-system/tokens.md §Breakpoints (2 / 3 / 4 / 5).
   static int gridColumnsForWidth(BuildContext context) =>
-      gridColumnsForWidthValue(MediaQuery.sizeOf(context).width);
+      gridColumnsForContainerWidth(MediaQuery.sizeOf(context).width);
 
-  /// Column count for a grid with the given explicit [width] (dp).
+  /// Listing-grid column count for a given **container width** (e.g. the
+  /// `crossAxisExtent` reported by `SliverLayoutBuilder`). Returns the same
+  /// 2 / 3 / 4 / 5 progression as [gridColumnsForWidth] but tied to the
+  /// actual box a grid renders inside rather than the whole viewport. Use
+  /// this when a grid lives alongside a fixed-width sidebar or under a
+  /// `ResponsiveBody.wide` cap — those wrappers can shrink the grid's
+  /// effective width by hundreds of pixels below the viewport.
   ///
-  /// Use when the widget occupies only part of the viewport (e.g. a
-  /// sidebar-adjacent content pane) so the container width drives the column
-  /// decision rather than the full `MediaQuery` width.
-  static int gridColumnsForWidthValue(double width) {
+  /// Thresholds (same as [gridColumnsForWidth]):
+  /// - width <  [compact]  (600)  → 2
+  /// - width <  [medium]   (840)  → 3
+  /// - width <  [large]   (1200)  → 4
+  /// - width >= [large]   (1200)  → 5
+  static int gridColumnsForContainerWidth(double width) {
     if (width < compact) return 2;
     if (width < medium) return 3;
-    if (width >= large) return 5;
-    return 4;
+    if (width < large) return 4;
+    return 5;
   }
 }

--- a/lib/features/search/presentation/widgets/search_results_view.dart
+++ b/lib/features/search/presentation/widgets/search_results_view.dart
@@ -90,18 +90,16 @@ class SearchResultsView extends StatelessWidget {
         onAction: () => onFilterApply(SearchFilter(query: data.filter.query)),
       );
     }
-    // The results pane occupies (viewport − sidebar − 1 px divider) dp.
-    // Pass the container width to the grid so it picks the right column count
-    // rather than reading the full viewport via MediaQuery (#210 review C1).
-    final paneWidth =
-        MediaQuery.sizeOf(context).width - Breakpoints.filterSidebarWidth - 1;
-    final paneColumns = Breakpoints.gridColumnsForWidthValue(paneWidth);
+    // The grid is container-aware via SliverLayoutBuilder, so the column
+    // count is derived from the results pane's actual `crossAxisExtent`
+    // (viewport − sidebar − 1-px divider) rather than the full viewport
+    // via MediaQuery (#193 PR D / #210 review C1).
     return NotificationListener<ScrollNotification>(
       onNotification: _onScroll,
       child: CustomScrollView(
         slivers: [
           SliverToBoxAdapter(child: _buildResultCount(context)),
-          _buildGrid(context, crossAxisCountOverride: paneColumns),
+          _buildGrid(context),
           if (data.isLoadingMore) _loadMoreSpinner(),
           const SliverPadding(padding: EdgeInsets.only(bottom: Spacing.s8)),
         ],
@@ -172,10 +170,9 @@ class SearchResultsView extends StatelessWidget {
     );
   }
 
-  Widget _buildGrid(BuildContext context, {int? crossAxisCountOverride}) {
+  Widget _buildGrid(BuildContext context) {
     return AdaptiveListingGrid(
       itemCount: data.listings.length,
-      crossAxisCountOverride: crossAxisCountOverride,
       itemBuilder: (context, index) {
         final listing = data.listings[index];
         return EscrowAwareListingCard(

--- a/lib/widgets/cards/adaptive_listing_grid.dart
+++ b/lib/widgets/cards/adaptive_listing_grid.dart
@@ -5,17 +5,27 @@ import 'package:deelmarkt/core/design_system/spacing.dart';
 import 'package:deelmarkt/widgets/cards/deel_card_tokens.dart';
 
 /// Sliver grid for listing cards that adapts its column count to the
-/// viewport (2 / 3 / 4 / 5 per [Breakpoints.gridColumnsForWidth]) and uses
-/// the canonical [DeelCardTokens.gridChildAspectRatio] + standard spacing.
+/// **actual width of the container it renders inside** (via
+/// [SliverLayoutBuilder] + [Breakpoints.gridColumnsForContainerWidth]) and
+/// uses the canonical [DeelCardTokens.gridChildAspectRatio] + standard
+/// spacing.
+///
+/// Container-aware is critical: this grid renders alongside fixed sidebars
+/// (search filter panel), inside width-capped scroll views
+/// (`ResponsiveBody.wide`), and as a full-viewport grid on mobile. A
+/// viewport-based column count would produce 5 cols inside the ~1159-px
+/// search results pane (1400 viewport, minus 240-px sidebar, minus 1-px
+/// divider) — not enough horizontal room for `DeelCard` content, and the
+/// card would overflow by ~16 px vertically. Reading `crossAxisExtent`
+/// from the sliver's own constraints keeps the column count proportional
+/// to the space the grid actually occupies.
+///
+/// Full-width surfaces (home / favourites / category-detail without a
+/// sidebar) see identical column counts to the pre-migration behaviour
+/// because `crossAxisExtent` equals the viewport width there.
 ///
 /// Consumers: home nearby grid, search results, favourites, category detail,
 /// profile listings.
-///
-/// When the grid is placed inside a layout that occupies only part of the
-/// viewport (e.g. the results pane next to a filter sidebar), pass
-/// [crossAxisCountOverride] so the column count reflects the container width
-/// rather than the full `MediaQuery` width. Use
-/// [Breakpoints.gridColumnsForWidthValue] to compute the override.
 ///
 /// Reference: docs/design-system/tokens.md §Breakpoints, components.md §Listing Card.
 class AdaptiveListingGrid extends StatelessWidget {
@@ -23,7 +33,6 @@ class AdaptiveListingGrid extends StatelessWidget {
     required this.itemCount,
     required this.itemBuilder,
     this.padding = const EdgeInsets.symmetric(horizontal: Spacing.s4),
-    this.crossAxisCountOverride,
     super.key,
   });
 
@@ -31,30 +40,29 @@ class AdaptiveListingGrid extends StatelessWidget {
   final IndexedWidgetBuilder itemBuilder;
   final EdgeInsetsGeometry padding;
 
-  /// Explicit column count — overrides the viewport-based default.
-  ///
-  /// Set this when the grid does not span the full viewport width.
-  /// Compute via [Breakpoints.gridColumnsForWidthValue].
-  final int? crossAxisCountOverride;
-
   @override
   Widget build(BuildContext context) {
-    final columns =
-        crossAxisCountOverride ?? Breakpoints.gridColumnsForWidth(context);
-    return SliverPadding(
-      padding: padding,
-      sliver: SliverGrid(
-        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: columns,
-          mainAxisSpacing: Spacing.listingCardGap,
-          crossAxisSpacing: Spacing.listingCardGap,
-          childAspectRatio: DeelCardTokens.gridChildAspectRatio,
-        ),
-        delegate: SliverChildBuilderDelegate(
-          itemBuilder,
-          childCount: itemCount,
-        ),
-      ),
+    return SliverLayoutBuilder(
+      builder: (context, constraints) {
+        final columns = Breakpoints.gridColumnsForContainerWidth(
+          constraints.crossAxisExtent,
+        );
+        return SliverPadding(
+          padding: padding,
+          sliver: SliverGrid(
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: columns,
+              mainAxisSpacing: Spacing.listingCardGap,
+              crossAxisSpacing: Spacing.listingCardGap,
+              childAspectRatio: DeelCardTokens.gridChildAspectRatio,
+            ),
+            delegate: SliverChildBuilderDelegate(
+              itemBuilder,
+              childCount: itemCount,
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/widgets/cards/adaptive_listing_grid.dart
+++ b/lib/widgets/cards/adaptive_listing_grid.dart
@@ -14,11 +14,11 @@ import 'package:deelmarkt/widgets/cards/deel_card_tokens.dart';
 /// (search filter panel), inside width-capped scroll views
 /// (`ResponsiveBody.wide`), and as a full-viewport grid on mobile. A
 /// viewport-based column count would produce 5 cols inside the ~1159-px
-/// search results pane (1400 viewport, minus 240-px sidebar, minus 1-px
-/// divider) — not enough horizontal room for `DeelCard` content, and the
-/// card would overflow by ~16 px vertically. Reading `crossAxisExtent`
-/// from the sliver's own constraints keeps the column count proportional
-/// to the space the grid actually occupies.
+/// search results pane (1400-px viewport, minus 240-px sidebar, minus
+/// 1-px divider) — not enough horizontal room for `DeelCard` content, and
+/// the card would overflow by ~16 px vertically. Reading
+/// `crossAxisExtent` from the sliver's own constraints keeps the column
+/// count proportional to the space the grid actually occupies.
 ///
 /// Full-width surfaces (home / favourites / category-detail without a
 /// sidebar) see identical column counts to the pre-migration behaviour

--- a/test/core/design_system/breakpoints_test.dart
+++ b/test/core/design_system/breakpoints_test.dart
@@ -203,6 +203,48 @@ void main() {
       expect(result, isFalse);
     });
 
+    test('gridColumnsForContainerWidth returns 2/3/4/5 per threshold', () {
+      expect(Breakpoints.gridColumnsForContainerWidth(400), 2);
+      expect(Breakpoints.gridColumnsForContainerWidth(599.9), 2);
+      expect(Breakpoints.gridColumnsForContainerWidth(600), 3);
+      expect(Breakpoints.gridColumnsForContainerWidth(700), 3);
+      expect(Breakpoints.gridColumnsForContainerWidth(839.9), 3);
+      expect(Breakpoints.gridColumnsForContainerWidth(840), 4);
+      expect(Breakpoints.gridColumnsForContainerWidth(900), 4);
+      expect(Breakpoints.gridColumnsForContainerWidth(1199.9), 4);
+      expect(Breakpoints.gridColumnsForContainerWidth(1200), 5);
+      expect(Breakpoints.gridColumnsForContainerWidth(1400), 5);
+      expect(Breakpoints.gridColumnsForContainerWidth(1800), 5);
+    });
+
+    testWidgets(
+      'gridColumnsForWidth delegates to gridColumnsForContainerWidth via MediaQuery',
+      (tester) async {
+        tester.view.physicalSize = const Size(959, 900);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        late int contextResult;
+        late int directResult;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Builder(
+              builder: (context) {
+                contextResult = Breakpoints.gridColumnsForWidth(context);
+                directResult = Breakpoints.gridColumnsForContainerWidth(
+                  MediaQuery.sizeOf(context).width,
+                );
+                return const SizedBox();
+              },
+            ),
+          ),
+        );
+        expect(contextResult, directResult);
+        expect(contextResult, 4); // 959 < 1200
+      },
+    );
+
     testWidgets('gridColumnsForWidth returns 2/3/4/5 per breakpoint', (
       tester,
     ) async {

--- a/test/widgets/cards/adaptive_listing_grid_test.dart
+++ b/test/widgets/cards/adaptive_listing_grid_test.dart
@@ -5,25 +5,34 @@ import 'package:deelmarkt/core/design_system/spacing.dart';
 import 'package:deelmarkt/widgets/cards/adaptive_listing_grid.dart';
 import 'package:deelmarkt/widgets/cards/deel_card_tokens.dart';
 
-Widget _buildGridApp({required double width, int itemCount = 8}) {
-  return MediaQuery(
-    data: MediaQueryData(size: Size(width, 1200)),
-    child: MaterialApp(
-      home: Scaffold(
-        body: CustomScrollView(
-          slivers: [
-            AdaptiveListingGrid(
-              itemCount: itemCount,
-              itemBuilder:
-                  (context, index) => ColoredBox(
-                    color: Colors.grey,
-                    key: ValueKey('cell-$index'),
-                  ),
-            ),
-          ],
-        ),
+/// Sets the actual test-view physical size so `SliverLayoutBuilder`
+/// reports a matching `crossAxisExtent`. Replacing a fake `MediaQuery`
+/// with this is necessary post-#193 PR D — the grid now reads the
+/// real sliver constraints, not `MediaQuery.sizeOf`.
+Future<void> _pumpGridAt(
+  WidgetTester tester, {
+  required double width,
+  int itemCount = 8,
+  Widget Function(Widget child)? wrap,
+}) async {
+  tester.view.physicalSize = Size(width, 1200);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  final grid = CustomScrollView(
+    slivers: [
+      AdaptiveListingGrid(
+        itemCount: itemCount,
+        itemBuilder:
+            (context, index) =>
+                ColoredBox(color: Colors.grey, key: ValueKey('cell-$index')),
       ),
-    ),
+    ],
+  );
+
+  await tester.pumpWidget(
+    MaterialApp(home: Scaffold(body: wrap?.call(grid) ?? grid)),
   );
 }
 
@@ -35,37 +44,97 @@ int _crossAxisCount(WidgetTester tester) {
 }
 
 void main() {
-  group('AdaptiveListingGrid', () {
+  group('AdaptiveListingGrid — full-width viewport', () {
     testWidgets('uses 2 columns at 400px (compact)', (tester) async {
-      await tester.pumpWidget(_buildGridApp(width: 400));
+      await _pumpGridAt(tester, width: 400);
       expect(_crossAxisCount(tester), 2);
     });
 
     testWidgets('uses 3 columns at 700px (medium)', (tester) async {
-      await tester.pumpWidget(_buildGridApp(width: 700));
+      await _pumpGridAt(tester, width: 700);
       expect(_crossAxisCount(tester), 3);
     });
 
     testWidgets('uses 4 columns at 900px (expanded)', (tester) async {
-      await tester.pumpWidget(_buildGridApp(width: 900));
+      await _pumpGridAt(tester, width: 900);
       expect(_crossAxisCount(tester), 4);
     });
 
     testWidgets('uses 5 columns at 1400px (large)', (tester) async {
-      await tester.pumpWidget(_buildGridApp(width: 1400));
+      await _pumpGridAt(tester, width: 1400);
       expect(_crossAxisCount(tester), 5);
     });
 
     testWidgets('uses canonical aspect ratio and listingCardGap spacing', (
       tester,
     ) async {
-      await tester.pumpWidget(_buildGridApp(width: 900));
+      await _pumpGridAt(tester, width: 900);
       final grid = tester.widget<SliverGrid>(find.byType(SliverGrid));
       final delegate =
           grid.gridDelegate as SliverGridDelegateWithFixedCrossAxisCount;
       expect(delegate.childAspectRatio, DeelCardTokens.gridChildAspectRatio);
       expect(delegate.mainAxisSpacing, Spacing.listingCardGap);
       expect(delegate.crossAxisSpacing, Spacing.listingCardGap);
+    });
+  });
+
+  group('AdaptiveListingGrid — container-aware (#193 PR D)', () {
+    testWidgets(
+      'column count tracks sidebar-constrained pane, not viewport '
+      '(1400 viewport - 240 sidebar - 1 divider = 959 pane → 4 cols, not 5)',
+      (tester) async {
+        await _pumpGridAt(
+          tester,
+          width: 1400,
+          wrap:
+              (grid) => Row(
+                children: [
+                  const SizedBox(width: 240),
+                  const VerticalDivider(width: 1),
+                  Expanded(child: grid),
+                ],
+              ),
+        );
+        // Pane width ≈ 1400 - 240 - 1 = 1159, which is still < 1200 so the
+        // helper returns 4 (not 5). This is the bug the refactor fixes:
+        // before #193 PR D, the viewport-based helper would return 5 here.
+        expect(_crossAxisCount(tester), 4);
+      },
+    );
+
+    testWidgets('column count tracks ResponsiveBody.wide-capped pane '
+        '(1800 viewport, container capped at 1200 → 5 cols from container)', (
+      tester,
+    ) async {
+      await _pumpGridAt(
+        tester,
+        width: 1800,
+        wrap:
+            (grid) => Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 1200),
+                child: grid,
+              ),
+            ),
+      );
+      // 1200 cap is EXACTLY the `large` threshold → gets 5 cols because
+      // the helper uses `< large` (i.e. strictly less than 1200) → 4;
+      // at exactly 1200 → 5.
+      expect(_crossAxisCount(tester), 5);
+    });
+
+    testWidgets('column count drops to 3 when container narrows below medium '
+        '(800 pane inside 1400 viewport → 3 cols)', (tester) async {
+      await _pumpGridAt(
+        tester,
+        width: 1400,
+        wrap:
+            (grid) => Row(
+              children: [const SizedBox(width: 600), Expanded(child: grid)],
+            ),
+      );
+      // 1400 - 600 = 800 → medium range → 3 cols (was 5 pre-fix).
+      expect(_crossAxisCount(tester), 3);
     });
   });
 }

--- a/test/widgets/cards/adaptive_listing_grid_test.dart
+++ b/test/widgets/cards/adaptive_listing_grid_test.dart
@@ -81,7 +81,7 @@ void main() {
   group('AdaptiveListingGrid — container-aware (#193 PR D)', () {
     testWidgets(
       'column count tracks sidebar-constrained pane, not viewport '
-      '(1400 viewport - 240 sidebar - 1 divider = 959 pane → 4 cols, not 5)',
+      '(1400 viewport - 240 sidebar - 1 divider = 1159 pane → 4 cols, not 5)',
       (tester) async {
         await _pumpGridAt(
           tester,


### PR DESCRIPTION
Follow-up to #193 PR C (#210). Surfaced during the search desktop sidebar work: at a 1400-px viewport with a 240-px sidebar and 1-px divider, the results pane is 1159 px but `AdaptiveListingGrid.gridColumnsForWidth` (reading `MediaQuery.sizeOf`) still returned 5 cols — DeelCard's fixed aspect ratio then overflowed those narrower cells by ~16 px vertically. This PR flips the grid from **viewport-aware** to **container-aware** so the column count always tracks the actual space the grid occupies.

## Changes

### `lib/core/design_system/breakpoints.dart`
- **New** `gridColumnsForContainerWidth(double width)` — same 600/840/1200 thresholds, same 2/3/4/5 progression, but accepts a raw width from the caller's own layout constraints. Thresholds:
  - `width < compact` (600) → 2
  - `width < medium` (840) → 3
  - `width < large` (1200) → 4
  - `width >= large` (1200) → 5
- Existing `gridColumnsForWidth(BuildContext)` now **delegates** to `gridColumnsForContainerWidth(MediaQuery.sizeOf(context).width)` so call sites that genuinely want viewport-width semantics keep working.

### `lib/widgets/cards/adaptive_listing_grid.dart`
- Wraps the `SliverGrid` in `SliverLayoutBuilder` and uses `constraints.crossAxisExtent` for the column count. Same widget API, same callers, container-aware behaviour.
- Dartdoc expanded with the sidebar/wrapped-cap rationale so future contributors know why `SliverLayoutBuilder` was picked over the simpler viewport read.

## Why this is safe for existing consumers

Full-width surfaces (home / favourites / category-detail without a sidebar) see **identical column counts** because `crossAxisExtent == viewport` when the grid lives inside a `CustomScrollView` whose parent fills the viewport. Only constrained-container cases change — which is exactly where the old code produced bad layouts.

Behaviour impact on affected screens:

| Screen | Viewport 1400 | Pre-fix cols | Post-fix cols | Δ |
|:-------|:--------------|:-------------|:--------------|:--|
| Home (no sidebar, no wide cap) | 1400 container | 5 | 5 | ✓ |
| Favourites (wide cap 1200) | 1200 container | 5 | 5 | ✓ |
| Category-detail (wide cap 1200) | 1200 container | 5 | 5 | ✓ |
| **Search expanded (240 sidebar)** | **~1159 container** | **5 (overflowed)** | **4** | 🐛→✅ |

The search case is the only behaviour change — and it's the bug fix.

## Screenshot goldens

- `adaptive_listing_grid_{400,700,1400}.png` pass **byte-identical** (within the 0.5% tolerance) because the existing tests use viewport == container. ✅
- No consumer-screen golden regeneration expected. After PR C merges and the search desktop driver is revived (follow-up), the PNG will show the correct 4-col pane instead of the broken 5-col overflow.

## Test plan

- [x] `flutter analyze --no-pub` — zero warnings
- [x] `flutter test test/features/home test/features/search test/widgets` — **993 tests pass**
- [x] `flutter test test/widgets/cards/adaptive_listing_grid_test.dart` — **8/8 pass** (4 full-width regression pins + 3 container-aware cases + 1 invariants)
- [x] `flutter test test/widgets/cards/adaptive_listing_grid_golden_test.dart` — 3/3 PASS (0.05–0.11% diff, within tolerance)
- [x] `flutter test test/core/design_system/breakpoints_test.dart` — delegation parity + threshold coverage
- [x] Pre-commit + pre-push hooks all green (analyze strict, SonarCloud proxy, coverage, CLAUDE.md rules)

## References

- Issue: #193 §Scope (search sidebar follow-up from PR C)
- Siblings: #208 (PR A), #209 (PR B), #210 (PR C)
- Follow-up enabled: search desktop screenshot driver (deferred in PR C because DeelCard overflowed; can land once this PR + PR C both merge)