### PR TITLE
test(screenshots): add search desktop screenshot driver (#193 PR E)

### DIFF
--- a/test/screenshots/drivers/search_desktop_screenshot_test.dart
+++ b/test/screenshots/drivers/search_desktop_screenshot_test.dart
@@ -1,0 +1,59 @@
+/// Screenshot driver — Search results screen on desktop.
+///
+/// Captures the master-detail layout introduced in #193 PR C: 240-px filter
+/// sidebar (`Breakpoints.filterSidebarWidth`) on the left, results grid on
+/// the right. Matches `docs/screens/02-home/designs/search_desktop_results_sidebar`.
+///
+/// Mobile coverage stays in `search_screenshot_test.dart` (horizontal chip
+/// bar + bottom-sheet flow). This driver only fires on the
+/// `desktop_1400` frame from `kScreenshotDesktopDevices`.
+///
+/// ### Why this driver could not ship in PR #210
+///
+/// `AdaptiveListingGrid` previously read `MediaQuery.sizeOf` (viewport
+/// width) and returned 5 cols inside the 1159-px results pane (1400 viewport
+/// minus 240-px sidebar minus 1-px divider) — `DeelCard` then overflowed
+/// vertically by ~16 px. PR #213 made the grid container-aware via
+/// `SliverLayoutBuilder` + `Breakpoints.gridColumnsForContainerWidth`, so
+/// the pane now correctly resolves to 4 cols and the screen captures
+/// without overflow. This driver is the regression pin for that fix.
+///
+/// ### Scope — light theme only, for now
+///
+/// Dark-theme async-built screens trip the pre-existing `captureScreenshot`
+/// pre-paint-frame bug (see #203) — the search results grid watches an
+/// `AsyncNotifier` chain and falls into the same class as the other
+/// affected surfaces. Reintroduce
+/// `for (final theme in ScreenshotTheme.values)` once #203 lands.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:deelmarkt/features/search/presentation/search_screen.dart';
+
+import '../_support/device_frames.dart';
+import '../_support/screenshot_driver.dart';
+import '../_support/seed_data.dart';
+
+void main() {
+  setUpAll(initScreenshotEnvironment);
+
+  // Dark-theme goldens deliberately omitted per #203 — see library docstring.
+  for (final device in kScreenshotDesktopDevices) {
+    for (final locale in kScreenshotLocales) {
+      testWidgets('search_desktop ${device.id} $locale light', (tester) async {
+        await captureScreenshot(
+          tester: tester,
+          // Seed an initial query so the results grid + sidebar render
+          // instead of the initial recent-searches view. "fiets" returns
+          // results in both NL and EN mock data.
+          screen: const SearchScreen(initialQuery: 'fiets'),
+          locale: locale,
+          theme: ScreenshotTheme.light,
+          device: device,
+          goldenName: 'search_desktop',
+        );
+      });
+    }
+  }
+}


### PR DESCRIPTION
Follow-up unblocked by PR #213 (AdaptiveListingGrid container-aware refactor) and PR #211 (#203 diagnostic gate).

## Summary

The driver was deferred from PR #210 / PR C because the viewport-based grid returned 5 cols inside the 1159-px results pane (1400 viewport - 240 sidebar - 1 divider) and `DeelCard` overflowed by ~16 px vertically. PR #213 made the grid use `SliverLayoutBuilder` + `Breakpoints.gridColumnsForContainerWidth`, so the pane now correctly resolves to 4 cols and the screen captures cleanly.

This PR closes that loop by shipping the screenshot driver that PR #210 had to skip.

## What ships

- `test/screenshots/drivers/search_desktop_screenshot_test.dart` — new driver iterating `kScreenshotDesktopDevices` × `kScreenshotLocales` × `ScreenshotTheme.light` (2 cases). Seeds an initial `'fiets'` query so the results grid + 240-px sidebar render instead of the initial recent-searches view. Matches `docs/screens/02-home/designs/search_desktop_results_sidebar`.
- Light-only per #203 — consistent with the other PR #193 desktop drivers (`home_buyer_desktop`, `favourites_desktop`, `category_browse_desktop`, `category_detail_desktop`). Reintroduce dark variants once #203's fix lands and the canary in `chat_thread_screenshot_test.dart` flips GREEN.

## Why this is safe to ship now

PR #213's container-aware `AdaptiveListingGrid` refactor was the prerequisite. Verified locally:

- `flutter test test/screenshots/drivers/search_desktop_screenshot_test.dart` — 2/2 cases pump cleanly, no `RenderFlex` overflow assertions thrown.
- The pane now resolves to **4 cols at `desktop_1400`** (1159 px container < 1200 `large` threshold), not 5.

Pixel comparison runs on `macos-14` CI per `screenshot_driver.dart:183`; Windows local runs only validate the widget tree pumps cleanly. macos-14 will produce the 2 new `search_desktop` PNGs on first run.

## Acceptance criteria check from issue #193

- [x] Search desktop screenshot driver shipped.
- [x] No `DeelCard` overflow at `desktop_1400` (validated by PR #213's grid refactor + this PR's clean pump).
- [ ] Dark-theme variants — deferred to the eventual #203 fix PR per the established convention across all PR #193 desktop drivers.

## Test plan

- [x] `flutter analyze --no-pub test/screenshots/drivers/search_desktop_screenshot_test.dart` — zero warnings
- [x] `flutter test test/screenshots/drivers/search_desktop_screenshot_test.dart` — 2/2 pass on Windows (pumps validate; pixel match skipped)
- [x] Pre-commit + pre-push hooks — all green
- [ ] macOS CI generates and commits 2 new `search_desktop_*_light_desktop_1400.png` PNGs

## References

- Issue: #193 §Scope item 2 (search sidebar — screenshot follow-up)
- Unblocking PR: #213 (`AdaptiveListingGrid` container-aware via `SliverLayoutBuilder`)
- Sibling drivers: `home_buyer_desktop`, `favourites_desktop`, `category_browse_desktop`, `category_detail_desktop`, `messages_shell_screenshot_test`
- Diagnostic gate (any future regression to identical pairs): #211 `dart run scripts/check_quality.dart --check-goldens`