### PR TITLE
docs(screenshots): post-#216 root-cause update for #203

### DIFF
--- a/docs/PLAN-screenshot-golden-fix.md
+++ b/docs/PLAN-screenshot-golden-fix.md
@@ -27,17 +27,80 @@ loading frame produces.
 
 ## Why this PR is diagnostic-only
 
-Two production-hardening attempts were made on this branch and reverted
-(see `git log` before `HEAD`):
+Three production-hardening attempts were made and reverted (see `git
+log` for the relevant branches):
 
-1. **`runAsync` pump sequence.** Replaced the fixed `pump(600ms)` with
-   `pump → runAsync(600ms) → pump → pumpAndSettle`. CI ran the gate after
-   the regen step and reported the same **100 identical pairs** — the
-   pump fix did not change the captured bytes.
-2. **`sqflite_common_ffi` + `path_provider` channel mock.** Three layers
-   of native-plugin shimming added a 3 MB native dep without unblocking
-   any failing pair. `databaseFactoryFfiNoIsolate` workaround for
-   `flutter_cache_manager` introduced more surface than it fixed.
+1. **`runAsync` pump sequence (#211 round 1).** Replaced the fixed
+   `pump(600ms)` with `pump → runAsync(600ms) → pump → pumpAndSettle`.
+   CI ran the gate after the regen step and reported the same **100
+   identical pairs** — the pump fix did not change the captured bytes.
+2. **`sqflite_common_ffi` + `path_provider` channel mock (#211 round
+   2).** Three layers of native-plugin shimming added a 3 MB native dep
+   without unblocking any failing pair. `databaseFactoryFfiNoIsolate`
+   workaround for `flutter_cache_manager` introduced more surface than
+   it fixed.
+3. **Two-phase `runAsync(200ms) + pump(600ms) + pump(100ms)` drain
+   (#216).** Same outcome as attempt 1 — CI's `Regenerate & Diff
+   Screenshots` job reported **100 identical pairs** unchanged. The
+   pump rewrite produced zero byte differences in the captured PNGs.
+
+## Updated root-cause hypothesis (post-#216)
+
+Pixel-level inspection of the 240 PNGs currently committed on `dev`
+shows the failure mode is **not** a pre-paint solid-color frame — it
+is a **fully transparent canvas**. Every pixel of every "broken" PNG
+is `(0, 0, 0, 0)` (RGBA zero), meaning the widget tree never painted
+to the snapshot surface at all.
+
+Bucketed by theme × device:
+
+| Bucket | content | transparent |
+|:------|:--------|:------------|
+| `light/ios_67` | **20** | 0 |
+| `light/desktop_1400` | **10** | 0 |
+| every other `(theme, device)` | 0 | 220 |
+
+So 30/240 PNGs (12.5%) render content. The 30 that paint share two
+properties:
+
+- They are the **first iteration** of their driver's
+  `for (device) → for (locale) → for (theme)` loop. `ios_67` is the
+  first entry in `kScreenshotDevices`; `desktop_1400` is the only
+  entry in `kScreenshotDesktopDevices`.
+- They are **light theme**.
+
+Subsequent iterations within the same driver (different device, or
+dark theme on the same device) consistently produce empty canvases
+even though the driver does:
+
+```dart
+await tester.binding.setSurfaceSize(device.logicalSize);
+addTearDown(() => tester.binding.setSurfaceSize(null));
+```
+
+This points at a **test-isolation defect** between `testWidgets`
+iterations sharing the same binding, not an async-build draining
+problem. Hypotheses worth testing:
+
+1. `setSurfaceSize` does not actually take effect for the second+
+   iteration without an additional `tester.pump()` cycle before
+   `pumpWidget`.
+2. The `goldenFileComparator` singleton (set in `setUpAll` to
+   `TolerantGoldenFileComparator.forTestFile(…)`) caches the first
+   surface and emits transparent for non-matching dimensions.
+3. The `RasterCache` retains the previous test's loading-frame layer
+   and serves a transparent texture when the next test rebuilds at a
+   different surface size.
+4. Riverpod's global `ProviderContainer` retains state from the prior
+   test run; the second `pumpWidget` builds on a disposed container.
+5. `EasyLocalization`'s asset cache is request-once; subsequent tests
+   await a never-firing locale future.
+
+A useful diagnostic before another fix attempt: dump
+`tester.binding.renderView.previousLayer` and `find.byType(MaterialApp)
+.evaluate().single.renderObject` after each pump phase, in the
+**second** iteration of the canary, to confirm which phase swaps in
+(or fails to swap in) the loaded layer.
 
 Mahmut's review on PR #211
 ([Round 1](https://github.com/deelmarkt-org/app/pull/211#pullrequestreview-2473),
@@ -64,18 +127,28 @@ No production code change. No new dependencies.
 The follow-up that closes #203 must:
 
 1. Make `--check-goldens` pass GREEN on CI (zero identical pairs after
-   regen).
+   regen) **and** verify via pixel inspection that all 240 PNGs are
+   non-transparent (`alpha != 0` somewhere on each canvas).
 2. Remove the `skip:` from the chat_thread canary; the canary must pass.
-3. Not introduce native-only dependencies (`sqflite_common_ffi`,
-   `path_provider` mocks). The fix lives in the pump sequence or in how
-   `captureScreenshot` builds its widget tree.
-4. Re-enable `ScreenshotTheme.values` (instead of `[ScreenshotTheme.light]`)
+   The canary now asserts `find.byType(MessageBubble)
+   .findsAtLeastNWidgets(1)` — a sharper signal than the original
+   widget-count > 50 (skeleton trees can satisfy that).
+3. Demonstrate test-isolation correctness: capture the second iteration
+   of the canary (e.g. `ios_65 + dark`) and assert the same widget
+   presence + non-transparent pixel sample.
+4. Not introduce native-only dependencies (`sqflite_common_ffi`,
+   `path_provider` mocks). The fix lives in driver setup/teardown,
+   pump sequence, or how `captureScreenshot` builds its widget tree.
+5. Re-enable `ScreenshotTheme.values` (instead of `[ScreenshotTheme.light]`)
    in the desktop drivers introduced in #193:
    - `home_buyer_desktop_screenshot_test.dart`
    - `favourites_desktop_screenshot_test.dart`
    - `category_detail_desktop_screenshot_test.dart`
    - `category_browse_desktop_screenshot_test.dart`
    - `messages_shell_desktop_screenshot_test.dart`
+6. Auto-commit step in `screenshots.yml` should run **after**
+   `--check-goldens` passes; otherwise a failing gate auto-pushes
+   broken baselines back to the PR branch (regression seen in #216).
 
 Until then, the desktop drivers stay light-only and the dark-mode
 visual regression surface for those screens remains uncovered.

--- a/test/screenshots/drivers/chat_thread_screenshot_test.dart
+++ b/test/screenshots/drivers/chat_thread_screenshot_test.dart
@@ -8,6 +8,7 @@ library;
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:deelmarkt/features/messages/presentation/screens/chat_thread_screen.dart';
+import 'package:deelmarkt/features/messages/presentation/widgets/message_bubble.dart';
 
 import '../_support/device_frames.dart';
 import '../_support/screenshot_driver.dart';
@@ -37,25 +38,31 @@ void main() {
     }
   }
 
-  // Canary — async-provider resolution baseline (issue #203).
+  // Canary — loaded-state baseline for issue #203.
   //
-  // Inspects the widget tree AFTER `captureScreenshot` returns. A fully
-  // loaded `ChatThreadScreen` renders an AppBar, message list, message
-  // bubbles, timestamps and an input field — well over 50 widgets. A
-  // skeleton/loading state renders only Shimmer containers (< 20 widgets).
+  // Inspects the widget tree AFTER `captureScreenshot` returns. A loaded
+  // `ChatThreadScreen` renders one or more [MessageBubble]s for the seeded
+  // `conv-001` thread; a skeleton/loading state renders zero. Asserting on
+  // the presence of `MessageBubble` (rather than a raw widget count, which
+  // skeleton trees can satisfy) gives a sharp signal of whether the
+  // capture pipeline ran to a loaded state before snapshotting.
   //
-  // Today this canary is expected to FAIL (or report a low widget count)
-  // because the pump sequence inside `captureScreenshot` does not drain
-  // `AsyncNotifier.build()` micro-tasks before the golden frame is taken.
-  // That's the exact bug #203 tracks.
+  // Today this canary is expected to FAIL because of the dual problem
+  // documented in `docs/PLAN-screenshot-golden-fix.md`:
+  //   1. `AsyncNotifier.build()` micro-tasks may not drain before the
+  //      golden frame is taken (the original #203 hypothesis).
+  //   2. Test-isolation defect — only the first `(device, locale, theme)`
+  //      iteration of each driver paints to its surface; subsequent
+  //      iterations capture a fully transparent canvas (220/240 PNGs in
+  //      `dev` are `(0,0,0,0)` across the whole frame).
   //
   // The canary lives in this PR (alongside the `--check-goldens` byte-
   // identity gate) so future fix attempts have a RED baseline to flip
-  // GREEN. It is platform-independent (widget count, not pixels) and runs
-  // on every CI runner, not just macOS.
-  group('canary — async provider resolution (#203)', () {
+  // GREEN. It is platform-independent (widget tree inspection, not
+  // pixels) and runs on every CI runner, not just macOS.
+  group('canary — loaded-state baseline (#203)', () {
     testWidgets(
-      'chat_thread widget tree must be in loaded state after pump',
+      'chat_thread renders MessageBubble after captureScreenshot pump',
       (tester) async {
         await captureScreenshot(
           tester: tester,
@@ -68,20 +75,19 @@ void main() {
           goldenName: 'chat_thread_canary',
         );
 
-        final widgetCount = tester.allWidgets.length;
         expect(
-          widgetCount,
-          greaterThan(50),
+          find.byType(MessageBubble),
+          findsAtLeastNWidgets(1),
           reason:
-              'Widget tree has only $widgetCount widgets after pump — '
-              'ChatThreadScreen is likely still in loading/skeleton state. '
-              'AsyncNotifier.build() may not have completed before golden '
-              'capture. Track via issue #203.',
+              'No MessageBubble in tree after pump — ChatThreadScreen is '
+              'still in loading/skeleton state. AsyncNotifier.build() did '
+              'not commit to the Element tree before golden capture, or '
+              'the screen never received a paint frame. Track via #203.',
         );
       },
-      // Expected to FAIL today — see canary docstring above. Skipped in CI
-      // to keep the screenshot pipeline green; remove `skip` once #203 lands
-      // a working pump fix and the canary turns GREEN.
+      // Expected to FAIL today — see canary docstring. Skipped in CI to
+      // keep the pipeline green; remove `skip` once #203 lands a fix and
+      // the canary turns GREEN as a permanent regression guard.
       skip: true, // Pending #203 — canary is the RED baseline for the fix PR.
     );
   });


### PR DESCRIPTION
## Status: 🚧 Draft — speculative fix retracted, deeper diagnosis required

This PR was opened as a pump-sequence fix for #203. Mahmut's review on the original commit (cebe0ca, now history) was correct: the change did not work on CI — `--check-goldens` reported the same **100 identical light/dark pairs** as `dev`. The pump rewrite produced zero byte differences in the captured PNGs.

The branch has been **reset to `origin/dev`** and re-scoped to a documentation-only update. The CI workflow, dark-variant re-enable, plan-doc deletion, and pump-sequence rewrite are all reverted.

## What this commit ships

- **Tightened canary assertion** (Mahmut H2): replaced the lenient `tester.allWidgets.length > 50` (skeleton trees can satisfy that) with `find.byType(MessageBubble).findsAtLeastNWidgets(1)`. The canary remains `skip:`-marked until #203 actually lands; it is now a sharper RED baseline for the next attempt.
- **Updated `docs/PLAN-screenshot-golden-fix.md`** with the post-#216 diagnosis from pixel-level inspection.

## Diagnostic finding (post-#216)

The failure mode is **not** "pre-paint solid color frame" — every pixel of every "broken" PNG is fully transparent (`RGBA 0,0,0,0` across the entire canvas). The widget tree never painted to the snapshot surface.

Bucketing the 240 committed PNGs by `(theme, device)`:

| bucket | content | transparent |
|:--|:--|:--|
| `light / ios_67` | **20** | 0 |
| `light / desktop_1400` | **10** | 0 |
| every other `(theme, device)` | 0 | 220 |

The 30 PNGs that paint share two properties:
- They are the **first iteration** of their driver's `for (device) → for (locale) → for (theme)` loop. `ios_67` is the first entry in `kScreenshotDevices`; `desktop_1400` is the only entry in `kScreenshotDesktopDevices`.
- They are **light theme**.

This points at a **test-isolation defect** between `testWidgets` iterations sharing the same binding, not an async-build draining problem. The previous three fix attempts (PR #211 round 1's `runAsync`, PR #211 round 2's `sqflite_common_ffi` cascade, PR #216's two-phase drain) all targeted async-draining and produced zero byte changes — consistent with the real root cause being elsewhere.

Five hypotheses for the next fix attempt are documented in the plan doc: `setSurfaceSize` sequencing, `goldenFileComparator` caching, `RasterCache` retention, Riverpod container reuse, EasyLocalization asset cache.

## Mahmut review feedback — disposition

| ID | Status |
|:--|:--|
| **C1** — pump fix didn't work on CI | ✅ Fix reverted; PR re-scoped to docs-only |
| **C2** — pre-ticked acceptance criterion | ✅ Original PR body removed; new body has no claims about CI passing |
| **C3** — auto-commit ordering pushed solid-color PNGs | ✅ Workflow change reverted; `screenshots.yml` is back to `dev` ordering |
| **H1** — five desktop drivers re-enabled `ScreenshotTheme.values` | ✅ Reverted to light-only with the existing `// TODO(#203)` |
| **H2** — canary `widget count > 50` is too lenient | ✅ Now asserts `find.byType(MessageBubble).findsAtLeastNWidgets(1)` |
| **H3** — `runAsync` was tried before; structural alternative needed | ✅ Acknowledged. Plan doc now documents diagnostic suggestion (dump `renderView.previousLayer` per phase in second canary iteration) before another pump attempt |
| **M1** — `docs/PLAN-screenshot-golden-fix.md` deletion premature | ✅ Restored + updated with post-#216 diagnosis |
| **M2** — `test/screenshots/README.md` Known Issues deletion premature | ✅ Restored to pre-#216 state |

## Next-step recommendation

Either of:

**Option A — close this PR**, leave #203 open for a future attempt that follows the new acceptance criteria in the plan doc.

**Option B — keep this PR as the docs/canary-tightening landing** so the diagnostic baseline gets richer for the next attempt, then merge the docs without claiming #203 closure.

I have no strong preference; happy to close if you'd rather have a clean slate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)